### PR TITLE
♻ Simpler integration with mbed-devices

### DIFF
--- a/mbed_tools/cli.py
+++ b/mbed_tools/cli.py
@@ -1,6 +1,6 @@
 """Integration point with all sub-packages."""
 import click
-from mbed_devices.mbed_tools.cli import cli as mbed_devices_cli
+from mbed_devices.mbed_tools import cli as mbed_devices_cli
 
 
 CONTEXT_SETTINGS = dict(help_option_names=["-h", "--help"])

--- a/news/20200316.misc
+++ b/news/20200316.misc
@@ -1,0 +1,1 @@
+Simpler integration with mbed-devices

--- a/tests/test_devices_command_integration.py
+++ b/tests/test_devices_command_integration.py
@@ -1,7 +1,7 @@
 from unittest import TestCase
 
 from mbed_tools.cli import cli
-from mbed_devices.mbed_tools.cli import cli as mbed_devices_cli
+from mbed_devices.mbed_tools import cli as mbed_devices_cli
 
 
 class TestDevicesCommandIntegration(TestCase):


### PR DESCRIPTION
### Description

Simplify import path for `mbed-tools` integration. It'll fail until `mbed-devices` is released.

https://github.com/ARMmbed/mbed-devices/pull/52

### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [x]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
