### PR TITLE
Catch and log ToolsErrors in main entry point

### DIFF
--- a/mbed_tools/cli.py
+++ b/mbed_tools/cli.py
@@ -1,15 +1,51 @@
 """Integration point with all sub-packages."""
+import logging
+
 import click
+
+from mbed_tools_lib.logging import log_exception, set_log_level
+from mbed_tools_lib.exceptions import ToolsError
+
 from mbed_devices.mbed_tools import cli as mbed_devices_cli
 
 
 CONTEXT_SETTINGS = dict(help_option_names=["-h", "--help"])
+LOGGER = logging.getLogger(__name__)
 
 
-@click.group(context_settings=CONTEXT_SETTINGS)
-def cli() -> None:
-    """Main entry point for the cli."""
-    pass
+class GroupWithExceptionHandling(click.Group):
+    """A click.Group which handles ToolsErrors and logging."""
+
+    def invoke(self, context: click.Context) -> None:
+        """Invoke the command group.
+
+        Args:
+            context: The current click context.
+        """
+        try:
+            super().invoke(context)
+        except ToolsError as err:
+            traceback = context.params["traceback"]
+            if LOGGER.level != logging.DEBUG and not traceback:
+                err = (
+                    f"{err} Increase the verbosity level to `-vvv` to see debug information."
+                    " Use the `--traceback` argument to see a full stack trace."
+                )
+            log_exception(LOGGER, err, traceback)
+
+
+@click.group(cls=GroupWithExceptionHandling, context_settings=CONTEXT_SETTINGS)
+@click.option(
+    "-v",
+    "--verbose",
+    default=0,
+    count=True,
+    help="Set the verbosity level, enter multiple times to increase verbosity.",
+)
+@click.option("-t", "--traceback", is_flag=True, show_default=True, help="Show a traceback when an error is raised.")
+def cli(verbose: int, traceback: bool) -> None:
+    """Command line tool for interacting with Mbed OS."""
+    set_log_level(verbose)
 
 
 cli.add_command(mbed_devices_cli, "devices")

--- a/mbed_tools/cli.py
+++ b/mbed_tools/cli.py
@@ -28,7 +28,7 @@ class GroupWithExceptionHandling(click.Group):
             traceback = context.params["traceback"]
             if LOGGER.level != logging.DEBUG and not traceback:
                 err = (
-                    f"{err} Increase the verbosity level to `-vvv` to see debug information."
+                    f"{err}\nIncrease the verbosity level to `-vvv` to see debug information."
                     " Use the `--traceback` argument to see a full stack trace."
                 )
             log_exception(LOGGER, err, traceback)

--- a/news/20200318.feature
+++ b/news/20200318.feature
@@ -1,0 +1,1 @@
+Catch and log ToolsErrors in the CLI

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
     description="Command line interface for Mbed OS.",
     keywords="Arm Mbed OS MbedOS cli command line tools",
     include_package_data=True,
-    install_requires=["python-dotenv", "Click==7.0", "mbed-devices"],
+    install_requires=["python-dotenv", "Click==7.0", "mbed-devices", "mbed_tools_lib"],
     license="Apache 2.0",
     long_description_content_type="text/markdown",
     long_description=long_description,

--- a/tests/test_devices_command_integration.py
+++ b/tests/test_devices_command_integration.py
@@ -1,9 +1,27 @@
-from unittest import TestCase
+from unittest import TestCase, mock
+
+import click
+from click.testing import CliRunner
 
 from mbed_tools.cli import cli
 from mbed_devices.mbed_tools import cli as mbed_devices_cli
+from mbed_tools_lib.exceptions import ToolsError
 
 
 class TestDevicesCommandIntegration(TestCase):
     def test_devices_is_integrated(self):
         self.assertEqual(cli.commands["devices"], mbed_devices_cli)
+
+
+class TestClickGroupWithExceptionHandling(TestCase):
+    @mock.patch("mbed_tools.cli.log_exception", autospec=True)
+    def test_logs_tools_errors(self, log_except):
+        def callback():
+            raise ToolsError()
+
+        mock_cli = click.Command("test", callback=callback)
+        cli.add_command(mock_cli, "test")
+
+        CliRunner().invoke(cli, ["test"])
+
+        log_except.assert_called_once()


### PR DESCRIPTION
### Description

Subclass `click.Group` so we can catch and log `ToolsErrors`

### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [x]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
