### PR TITLE
Add mbed export

### DIFF
--- a/mbed_tools/cli.py
+++ b/mbed_tools/cli.py
@@ -9,6 +9,7 @@ import click
 
 from mbed_tools_lib.logging import set_log_level, MbedToolsHandler
 
+from mbed_build.mbed_tools import cli as mbed_build_export_cli
 from mbed_devices.mbed_tools import cli as mbed_devices_cli
 from mbed_tools._internal.config_cli import cli as config_cli
 
@@ -46,5 +47,6 @@ def cli(verbose: int, traceback: bool) -> None:
     set_log_level(verbose)
 
 
+cli.add_command(mbed_build_export_cli, "export")
 cli.add_command(mbed_devices_cli, "devices")
 cli.add_command(config_cli, "config")

--- a/news/20200407.feature
+++ b/news/20200407.feature
@@ -1,0 +1,1 @@
+Add export command to tools

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setup(
     description="Command line interface for Mbed OS.",
     keywords="Arm Mbed OS MbedOS cli command line tools",
     include_package_data=True,
-    install_requires=["python-dotenv", "Click==7.0", "mbed-devices", "pdoc3", "mbed-tools-lib~=1.2"],
+    install_requires=["python-dotenv", "Click==7.0", "mbed-build", "mbed-devices", "pdoc3", "mbed-tools-lib~=1.2"],
     license="Apache 2.0",
     long_description_content_type="text/markdown",
     long_description=long_description,


### PR DESCRIPTION
### Description

Adds the export command to mbed-tools.

Usage currently:
`mbed-tools export -o "something" -t "GCC" -m "CY8CPROTO_062_4343W" -p "../mbed-os-example-blinky/"`


### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [x]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
