### PR TITLE
Fixing spelling error

### DIFF
--- a/mbed_tools/_internal/config_cli.py
+++ b/mbed_tools/_internal/config_cli.py
@@ -22,7 +22,7 @@ using a `.env` file containing the variable definitions as follows:
 
 VARIABLE=value
 
-Environment variables take precendence, meaning the values set in the file will be overriden
+Environment variables take precedence, meaning the values set in the file will be overriden
 by any values previously set in your environment.
 
 +---------------------------------------------------------------------------------+

--- a/news/20200408.bugfix
+++ b/news/20200408.bugfix
@@ -1,0 +1,1 @@
+Fixed spelling error


### PR DESCRIPTION
### Description
Just a small spelling error correction.


### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [ ]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [x]  Additional tests are not required for this change (e.g. documentation update).
