### PR TITLE
✨ Added --version option to print the version of all Mbed packages

### DIFF
--- a/news/20200422.feature
+++ b/news/20200422.feature
@@ -1,0 +1,1 @@
+Added --version option to return versions of all Mbed packages

--- a/tests/test_devices_command_integration.py
+++ b/tests/test_devices_command_integration.py
@@ -29,3 +29,11 @@ class TestClickGroupWithExceptionHandling(TestCase):
         CliRunner().invoke(cli, ["test"])
 
         logger_error.assert_called_once()
+
+
+class TestVersionCommand(TestCase):
+    def test_version_command(self):
+        runner = CliRunner()
+        result = runner.invoke(cli, ["--version"])
+        self.assertIn("mbed-tools", result.output)
+        self.assertEqual(0, result.exit_code)


### PR DESCRIPTION
### Description

The functionality of `mbed-tools` is determined by a number of Mbed packages, each implementing a different area. To improve the situation that exists with existing tools, where this often leads to confusion with the users, the new version command will print the versions of all Mbed tools packages. This should make it clearer to users that there is more that the single package at play and should make tackling support issues just a little bit easier.

### Test Coverage

- [x]  This change is covered by existing or additional automated tests.
- [x]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).

Manual testing

```
▶ mbed-tools --version
mbed-tools: 1.0.0
-----------------
mbed-build: 1.0.0b17
mbed-devices: 1.0.0b70
mbed-project: 0.1.0b16
mbed-targets: 1.0.0b154
mbed-tools-lib: 1.2.0
```