### PR TITLE
✨ Declare Python 3.8 support and add to CI

### DIFF
--- a/azure-pipelines/build-release.yml
+++ b/azure-pipelines/build-release.yml
@@ -36,6 +36,11 @@ stages:
               vmImageName: ubuntu-latest
               uploadCoverage: "true"
 
+            Linux_Py_3_8:
+              python.version: '3.8'
+              vmImageName: ubuntu-latest
+              uploadCoverage: "true"
+
             Windows_Py_3_6:
               python.version: '3.6'
               vmImageName: windows-latest
@@ -43,6 +48,11 @@ stages:
 
             Windows_Py_3_7:
               python.version: '3.7'
+              vmImageName: windows-latest
+              uploadCoverage: "false"
+
+            Windows_Py_3_8:
+              python.version: '3.8'
               vmImageName: windows-latest
               uploadCoverage: "false"
 
@@ -55,6 +65,12 @@ stages:
               python.version: '3.7'
               vmImageName: macOS-latest
               uploadCoverage: "false"
+
+            macOS_Py_3_8:
+              python.version: '3.8'
+              vmImageName: macOS-latest
+              uploadCoverage: "false"
+
         pool:
           vmImage: $(vmImageName)
 

--- a/azure-pipelines/build-release.yml
+++ b/azure-pipelines/build-release.yml
@@ -34,7 +34,7 @@ stages:
             Linux_Py_3_7:
               python.version: '3.7'
               vmImageName: ubuntu-latest
-              uploadCoverage: "true"
+              uploadCoverage: "false"
 
             Linux_Py_3_8:
               python.version: '3.8'

--- a/news/20200423.feature
+++ b/news/20200423.feature
@@ -1,0 +1,1 @@
+Support added for Python 3.8

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ setup(
         "Programming Language :: Python :: 3 :: Only",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
         "Topic :: Software Development :: Build Tools",
         "Topic :: Software Development :: Embedded Systems",
     ],


### PR DESCRIPTION
### Description

Python 3.8 is now in common usage:
- Update the package information to indicate Python 3.8 is supported.
- Add jobs to test with Python 3.8 on each host platform.



### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [x]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
