### PR TITLE
🚚 Config to env

### DIFF
--- a/mbed_tools/_internal/env_cli.py
+++ b/mbed_tools/_internal/env_cli.py
@@ -2,22 +2,22 @@
 # Copyright (C) 2020 Arm Mbed. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
-"""Exposes a click command which prints information about configuration variables of all child mbed packages."""
+"""Exposes a click command which prints information about environment variables of all child mbed packages."""
 import click
 import pdoc
 from typing import Iterable
 
 
-from mbed_devices.mbed_tools import config_variables as mbed_devices_config_variables
+from mbed_devices.mbed_tools import env_variables as mbed_devices_env_variables
 
 
 @click.command()
 def cli() -> None:
-    """Prints information about configuration variables of all child mbed packages."""
-    click.echo(_build_output(mbed_devices_config_variables))
+    """Prints information about environment variables of all child mbed packages."""
+    click.echo(_build_output(mbed_devices_env_variables))
 
 
-_OUTPUT_PREAMBLE = """All the configuration variables can be set either via environment variables or
+_OUTPUT_PREAMBLE = """These variables used by Mbed Tools can be set either directly via environment variables or
 using a `.env` file containing the variable definitions as follows:
 
 VARIABLE=value
@@ -33,8 +33,8 @@ by any values previously set in your environment.
 """
 
 
-def _build_output(config_variables: Iterable[pdoc.Variable]) -> str:
-    variables_outputs = [f"{v.name}\n\n{_tab_prefix(v.docstring)}" for v in config_variables]
+def _build_output(env_variables: Iterable[pdoc.Variable]) -> str:
+    variables_outputs = [f"{v.name}\n\n{_tab_prefix(v.docstring)}" for v in env_variables]
     variables_output = "\n\n".join(variables_outputs)
     return f"{_OUTPUT_PREAMBLE}\n\n{variables_output}"
 

--- a/mbed_tools/cli.py
+++ b/mbed_tools/cli.py
@@ -13,7 +13,7 @@ from mbed_tools_lib.logging import set_log_level, MbedToolsHandler
 
 from mbed_build.mbed_tools import cli as mbed_build_export_cli
 from mbed_devices.mbed_tools import cli as mbed_devices_cli
-from mbed_tools._internal.config_cli import cli as config_cli
+from mbed_tools._internal.env_cli import cli as env_cli
 
 
 CONTEXT_SETTINGS = dict(help_option_names=["-h", "--help"])
@@ -79,4 +79,4 @@ def cli(verbose: int, traceback: bool) -> None:
 
 cli.add_command(mbed_build_export_cli, "export-keys")
 cli.add_command(mbed_devices_cli, "devices")
-cli.add_command(config_cli, "config")
+cli.add_command(env_cli, "env")

--- a/news/20200423.misc
+++ b/news/20200423.misc
@@ -1,0 +1,1 @@
+Rename config to env.

--- a/tests/_internal/test_config_cli.py
+++ b/tests/_internal/test_config_cli.py
@@ -4,9 +4,9 @@
 #
 from click.testing import CliRunner
 from unittest import TestCase, mock
-from mbed_devices.mbed_tools import config_variables as mbed_devices_config_variables
+from mbed_devices.mbed_tools import env_variables as mbed_devices_env_variables
 
-from mbed_tools._internal.config_cli import (
+from mbed_tools._internal.env_cli import (
     _OUTPUT_PREAMBLE,
     _build_output,
     _tab_prefix,
@@ -14,12 +14,12 @@ from mbed_tools._internal.config_cli import (
 )
 
 
-class TestConfigCommand(TestCase):
-    def test_outputs_output_built_with_gathered_configuration_variables(self):
+class TestEnvCommand(TestCase):
+    def test_outputs_output_built_with_gathered_environment_variables(self):
         result = CliRunner().invoke(cli)
 
         self.assertEqual(result.exit_code, 0)
-        self.assertIn(_build_output(mbed_devices_config_variables), result.output)
+        self.assertIn(_build_output(mbed_devices_env_variables), result.output)
 
 
 class TestBuildOutput(TestCase):


### PR DESCRIPTION
### Description

Rename config to env since we want to have the config command free for Mbed config.



### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [x]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
