### PR TITLE
Config command

### DIFF
--- a/mbed_tools/cli.py
+++ b/mbed_tools/cli.py
@@ -11,7 +11,7 @@ import click
 
 from mbed_tools_lib.logging import set_log_level, MbedToolsHandler
 
-from mbed_build.mbed_tools import cli as mbed_build_export_cli
+from mbed_build.mbed_tools import export, config
 from mbed_devices.mbed_tools import cli as mbed_devices_cli
 from mbed_tools._internal.env_cli import cli as env_cli
 from mbed_project.mbed_tools.cli import init, clone, checkout, libs
@@ -78,7 +78,8 @@ def cli(verbose: int, traceback: bool) -> None:
     set_log_level(verbose)
 
 
-cli.add_command(mbed_build_export_cli, "export-keys")
+cli.add_command(export, "export-keys")
+cli.add_command(config, "config")
 cli.add_command(mbed_devices_cli, "devices")
 cli.add_command(env_cli, "env")
 cli.add_command(init, "init")

--- a/news/20200428.feature
+++ b/news/20200428.feature
@@ -1,0 +1,1 @@
+Add conig command.


### PR DESCRIPTION
### Description

Adding the 'config' command.  Build will fail until mbed-build is released.


### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [ ]  This change is covered by existing or additional automated tests.
- [x]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
