### PR TITLE
📌Add a version specifier to the dependencies for Mbed packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,12 @@
 
 ## Overview
 
-Command line interface for Mbed OS.
+This is the **future** command line tool for Mbed OS. It provides the ability to detect Mbed Enables devices connected
+by USB, checkout Mbed projects and perform builds amongst other operations.
+
+> :warning: While this package is generally available it is not complete. The available functionality can be viewed with
+> the `--help` option once installed. Please note that the current tools for Mbed OS 5.x and above can be found at
+> https://github.com/ARMmbed/mbed-cli.
 
 ## Releases
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 
 ## Overview
 
-This is the **future** command line tool for Mbed OS. It provides the ability to detect Mbed Enables devices connected
+This is the **future** command line tool for Mbed OS. It provides the ability to detect Mbed Enabled devices connected
 by USB, checkout Mbed projects and perform builds amongst other operations.
 
 > :warning: While this package is generally available it is not complete. The available functionality can be viewed with

--- a/news/20200428.misc
+++ b/news/20200428.misc
@@ -1,0 +1,1 @@
+Add a version specifier to the dependencies for Mbed packages

--- a/news/20200428.misc
+++ b/news/20200428.misc
@@ -1,1 +1,1 @@
-Add a version specifier to the dependencies for Mbed packages
+Add a version specifier to the dependencies for Mbed packages and a warning to the readme on package status

--- a/setup.py
+++ b/setup.py
@@ -42,9 +42,9 @@ setup(
     install_requires=[
         "python-dotenv",
         "Click==7.0",
-        "mbed-build",
-        "mbed-devices",
-        "mbed-project",
+        "mbed-build~=1.0",
+        "mbed-devices~=1.0",
+        "mbed-project~=1.0",
         "pdoc3",
         "mbed-tools-lib~=1.2",
     ],

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ setup(
         "Click==7.0",
         "mbed-build~=1.0",
         "mbed-devices~=1.0",
-        "mbed-project~=1.0",
+        "mbed-project~=2.0",
         "pdoc3",
         "mbed-tools-lib~=1.2",
     ],


### PR DESCRIPTION
### Description

So that we can make future breaking changes to Mbed packages relied on by mbed-tools, a version specifier is set for each Mbed package. This simplifies development, allowing internal interfaces to be changed while ensuring that new tools will not be installed if they are not compatible.

### Test Coverage

- [ ]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [x]  Additional tests are not required for this change (e.g. documentation update).
