### PR TITLE
Ensure the correct exit code is returned when a ToolsError is raised

### DIFF
--- a/mbed_tools/cli.py
+++ b/mbed_tools/cli.py
@@ -4,6 +4,7 @@
 #
 """Integration point with all sub-packages."""
 import logging
+import sys
 from pkg_resources import working_set
 
 from typing import Union, Any
@@ -32,9 +33,10 @@ class GroupWithExceptionHandling(click.Group):
         """
         # Use the context manager to ensure tools exceptions (expected behaviour) are shown as messages to the user,
         # but all other exceptions (unexpected behaviour) are shown as errors.
-        with MbedToolsHandler(LOGGER, context.params["traceback"]):
+        with MbedToolsHandler(LOGGER, context.params["traceback"]) as handler:
             super().invoke(context)
 
+        sys.exit(handler.return_code)
 
 def print_version(context: click.Context, param: Union[click.Option, click.Parameter], value: bool) -> Any:
     """A click callback which prints the versions of all Mbed Python packages."""

--- a/mbed_tools/cli.py
+++ b/mbed_tools/cli.py
@@ -38,6 +38,7 @@ class GroupWithExceptionHandling(click.Group):
 
         sys.exit(handler.return_code)
 
+
 def print_version(context: click.Context, param: Union[click.Option, click.Parameter], value: bool) -> Any:
     """A click callback which prints the versions of all Mbed Python packages."""
     if not value or context.resilient_parsing:

--- a/news/20200507.bugfix
+++ b/news/20200507.bugfix
@@ -1,0 +1,1 @@
+Exit with correct return code.


### PR DESCRIPTION
### Description

When ToolsErrors were raised the cli returned an exit code of 0.

This is dependent on https://github.com/ARMmbed/mbed-tools-lib/pull/22

### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [x]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
