### PR TITLE
 Declare MIT licence for zipp dependency 

### DIFF
--- a/news/20200701.bugfix
+++ b/news/20200701.bugfix
@@ -1,0 +1,1 @@
+Declare MIT license for zipp dependency

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ typing-extensions = "Actually licensed as PSF-2.0."
 chardet = "LGPL-2.1 - Accepted temporarily"
 pyudev = "LGPL-2.1 - Accepted temporarily"
 pdoc3 = "AGPL-3.0 - Accepted temporarily"
+zipp = "MIT"
 
 [AutoVersionConfig]
 CONFIG_NAME = "DEFAULT"


### PR DESCRIPTION
### Description

The SPDX checker tool couldn't find this licence, so was failing in CI.

Manually declare licence in pyproject.toml


### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [ ]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [x]  Additional tests are not required for this change (e.g. documentation update).
