### PR TITLE
 Rename export-keys command to export 

### DIFF
--- a/mbed_tools/cli.py
+++ b/mbed_tools/cli.py
@@ -79,7 +79,7 @@ def cli(verbose: int, traceback: bool) -> None:
 
 
 cli.add_command(build, "build")
-cli.add_command(export, "export-keys")
+cli.add_command(export, "export")
 cli.add_command(config, "config")
 cli.add_command(mbed_devices_cli, "devices")
 cli.add_command(env_cli, "env")

--- a/news/20200701.feature
+++ b/news/20200701.feature
@@ -1,0 +1,1 @@
+Rename export-keys command to export


### PR DESCRIPTION
### Description

Rename this command as it will export a full CMakelists.txt and toolchain file.


### Test Coverage

- [ ]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [x]  Additional tests are not required for this change (e.g. documentation update).
