### PR TITLE
Update mbed-build dependency

### DIFF
--- a/news/20200720152641.bugfix
+++ b/news/20200720152641.bugfix
@@ -1,0 +1,1 @@
+Pin mbed-build to ~1.2

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(
     install_requires=[
         "python-dotenv",
         "Click==7.0",
-        "mbed-build~=1.1",
+        "mbed-build~=1.2",
         "mbed-devices~=1.0",
         "mbed-project~=2.0",
         "pdoc3",


### PR DESCRIPTION
### Description

<!--
Please add any detail or context that would be useful to a reviewer.
-->

mbed-build was pinned to ~1.1, it's now at 1.2.2.


### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [x]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
