### PR TITLE
Do not install editable version of package in ci

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -3,6 +3,9 @@ name = "pypi"
 url = "https://pypi.org/simple"
 verify_ssl = true
 
+[packages]
+mbed-tools = {editable = true, path = "."}
+
 [dev-packages]
 black = "*"
 coverage = "*"
@@ -15,7 +18,6 @@ mypy = ">=0.500"
 pytest = "*"
 pytest-cov = "*"
 wheel = "*"
-mbed-tools = {editable = true, path = "."}
 mbed-tools-ci-scripts = "*"
 pre-commit = "*"
 requests-mock = "*"

--- a/azure-pipelines/steps/install-development-dependencies.yml
+++ b/azure-pipelines/steps/install-development-dependencies.yml
@@ -9,8 +9,9 @@ steps:
   - script: |
       python -m pip install --upgrade pip wheel setuptools
       pip install pipenv
-      python -m pipenv lock --dev -r --pre > dev-requirements.txt
+      python -m pipenv lock --dev-only -r --pre > dev-requirements.txt
       pip install -r dev-requirements.txt
       pip install pytest-azurepipelines
+      pip install .
       pip list
     displayName: 'Install development dependencies'

--- a/news/20200727201841.misc
+++ b/news/20200727201841.misc
@@ -1,0 +1,1 @@
+Use non-editable install of package in CI


### PR DESCRIPTION
### Description

<!--
Please add any detail or context that would be useful to a reviewer.
-->
The CI pipeline was using editable installs, so the tests failed to catch any packaging issues.

We now install the package to `site-packages` in CI, so we're testing what we actually deploy.


### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [x]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
