### PR TITLE
Update CMake template

### DIFF
--- a/news/20200727143830.bugfix
+++ b/news/20200727143830.bugfix
@@ -1,0 +1,1 @@
+Remove gen_config interface library target from cmake template

--- a/src/mbed_tools/build/_internal/templates/mbed_config.tmpl
+++ b/src/mbed_tools/build/_internal/templates/mbed_config.tmpl
@@ -4,8 +4,6 @@
 # Automatically generated configuration file.
 # DO NOT EDIT. Content may be overwritten.
 
-add_library(gen_config INTERFACE)
-
 set(MBED_TOOLCHAIN "{{toolchain_name}}" CACHE STRING "")
 set(MBED_TARGET "{{target_name}}" CACHE STRING "")
 set(MBED_CPU_CORE "{{core}}" CACHE STRING "")

--- a/src/mbed_tools/build/_internal/templates/mbed_config.tmpl
+++ b/src/mbed_tools/build/_internal/templates/mbed_config.tmpl
@@ -9,19 +9,19 @@ set(MBED_TARGET "{{target_name}}" CACHE STRING "")
 set(MBED_CPU_CORE "{{core}}" CACHE STRING "")
 set(MBED_PROFILE "develop" CACHE STRING "")
 
-set_property(GLOBAL APPEND PROPERTY MBED_TARGET_LABELS{% for label in labels %}
-    {{label}};
+list(APPEND MBED_TARGET_LABELS{% for label in labels %}
+    {{label}}
 {%- endfor %}
 {% for component in components %}
-    {{component}};
+    {{component}}
 {%- endfor %}
 {% for feature in features %}
-    {{feature}};
+    {{feature}}
 {%- endfor %}
 )
 
 # target
-add_definitions({% for component in components %}
+set(MBED_TARGET_DEFINITIONS{% for component in components %}
     -DCOMPONENT_{{component.upper()}}=1
 {%- endfor %}
 {% for feature in features %}
@@ -45,7 +45,7 @@ add_definitions({% for component in components %}
 )
 
 # config
-add_definitions(
+set(MBED_CONFIG_DEFINITIONS
 # options
 {% for option in options -%}
 {% if option.value is not none -%}


### PR DESCRIPTION
### Description

<!--
Please add any detail or context that would be useful to a reviewer.
-->

Remove gen_config INTERFACE library target.
Set variables instead of using add_definitions calls.

### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [ ]  This change is covered by existing or additional automated tests.
- [x]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).

```
(mbed-tools) robwal02@C02X70Z4JHD5 ~/p/m/p/mbed-os-example-blinky (feature-cmake)> mbedtools configure -t GCC_ARM -m k64f
mbed_config.cmake has been generated and written to '/Users/robwal02/projects/mbed/programs/mbed-os-example-blinky/.mbedbuild'
(mbed-tools) robwal02@C02X70Z4JHD5 ~/p/m/p/mbed-os-example-blinky (feature-cmake)> cat .mbedbuild/mbed_config.cmake
# Copyright (C) 2020 Arm Mbed. All rights reserved.
# SPDX-License-Identifier: Apache-2.0

# Automatically generated configuration file.
# DO NOT EDIT. Content may be overwritten.

set(MBED_TOOLCHAIN "GCC_ARM" CACHE STRING "")
set(MBED_TARGET "K64F" CACHE STRING "")
set(MBED_CPU_CORE "Cortex-M4F" CACHE STRING "")
set(MBED_PROFILE "develop" CACHE STRING "")

list(APPEND MBED_TARGET_LABELS
    MCU_K64F
    PSA_V7_M
    Freescale_EMAC
    Freescale
    CORTEX
    K64F
    MCUXpresso_MCUS
    FRDM
    Target
    KPSDK_CODE
    LIKE_CORTEX_M4
    PSA_Target
    KPSDK_MCUS
    KSDK2_MCUS
    CORTEX_M
    RTOS_M4_M7
    M4
    MBED_PSA_SRV

    FLASHIAP
    SD

    PSA
)

# target
set(MBED_TARGET_DEFINITIONS
    -DCOMPONENT_FLASHIAP=1
    -DCOMPONENT_SD=1                                                                                                                                                                                                                [531/9004]

    -DFEATURE_PSA=1

    -DDEVICE_CRC=1
    -DDEVICE_PWMOUT=1
    -DDEVICE_SPI_ASYNCH=1
    -DDEVICE_EMAC=1
    -DDEVICE_I2C=1
    -DDEVICE_I2CSLAVE=1
    -DDEVICE_SPI=1
    -DDEVICE_FLASH=1
    -DDEVICE_PORTOUT=1
    -DDEVICE_LPTICKER=1
    -DDEVICE_ANALOGOUT=1
    -DDEVICE_ANALOGIN=1
    -DDEVICE_RESET_REASON=1
    -DDEVICE_PORTINOUT=1
    -DDEVICE_SPISLAVE=1
    -DDEVICE_SERIAL_FC=1
    -DDEVICE_SLEEP=1
    -DDEVICE_USBDEVICE=1
    -DDEVICE_INTERRUPTIN=1
    -DDEVICE_TRNG=1
    -DDEVICE_SERIAL_ASYNCH=1
    -DDEVICE_STDIO_MESSAGES=1
    -DDEVICE_SERIAL=1
    -DDEVICE_RTC=1
    -DDEVICE_WATCHDOG=1
    -DDEVICE_PORTIN=1
    -DDEVICE_USTICKER=1

    -DTARGET_MCU_K64F
    -DTARGET_PSA_V7_M
    -DTARGET_Freescale_EMAC
    -DTARGET_Freescale
    -DTARGET_CORTEX
    -DTARGET_K64F
    -DTARGET_MCUXpresso_MCUS
    -DTARGET_FRDM
    -DTARGET_Target
    -DTARGET_KPSDK_CODE
    -DTARGET_LIKE_CORTEX_M4
    -DTARGET_PSA_Target
    -DTARGET_KPSDK_MCUS
    -DTARGET_KSDK2_MCUS
    -DTARGET_CORTEX_M
    -DTARGET_RTOS_M4_M7
    -DTARGET_M4
    -DTARGET_MBED_PSA_SRV

    -DFSL_RTOS_MBED
    -DCPU_MK64FN1M0VMD12
    -DMBED_SPLIT_HEAP
    -DMBED_TICKLESS

    -DTARGET_FF_ARDUINO
    -DMBED_BUILD_TIMESTAMP=1595969981.915132
    -DTARGET_LIKE_MBED
    -D__MBED__=1
)

# config
set(MBED_CONFIG_DEFINITIONS
# options
-DMBED_CONF_ALT1250_PPP_BAUDRATE=115200
-DMBED_CONF_ALT1250_PPP_PROVIDE_DEFAULT=0
-DMBED_CONF_ATMEL_RF_ASSUME_SPACED_SPI=0
-DMBED_CONF_ATMEL_RF_FULL_SPI_SPEED=7500000
-DMBED_CONF_ATMEL_RF_FULL_SPI_SPEED_BYTE_SPACING=250
-DMBED_CONF_ATMEL_RF_IRQ_THREAD_STACK_SIZE=1024
-DMBED_CONF_ATMEL_RF_LOW_SPI_SPEED=3750000
-DMBED_CONF_ATMEL_RF_PROVIDE_DEFAULT=0
-DMBED_CONF_ATMEL_RF_USE_SPI_SPACING_API=0
-DMBED_CONF_CELLULAR_CONTROL_PLANE_OPT=0
-DMBED_CONF_CELLULAR_DEBUG_AT=0
-DMBED_CONF_CELLULAR_MAX_CP_DATA_RECV_LEN=1358
-DMBED_CONF_CELLULAR_RANDOM_MAX_START_DELAY=0
-DMBED_CONF_CELLULAR_USE_APN_LOOKUP=0
-DMBED_CONF_CELLULAR_USE_SMS=0
-DMBED_CONF_DRIVERS_QSPI_CSN=QSPI_FLASH1_CSN
-DMBED_CONF_DRIVERS_QSPI_IO0=QSPI_FLASH1_IO0
-DMBED_CONF_DRIVERS_QSPI_IO1=QSPI_FLASH1_IO1
-DMBED_CONF_DRIVERS_QSPI_IO2=QSPI_FLASH1_IO2
-DMBED_CONF_DRIVERS_QSPI_IO3=QSPI_FLASH1_IO3
-DMBED_CONF_DRIVERS_QSPI_SCK=QSPI_FLASH1_SCK
-DMBED_CONF_DRIVERS_UART_SERIAL_RXBUF_SIZE=256
-DMBED_CONF_DRIVERS_UART_SERIAL_TXBUF_SIZE=256
-DMBED_CONF_ESP8266_BUILT_IN_DNS=0
-DMBED_CONF_ESP8266_DEBUG=0
-DMBED_CONF_ESP8266_POWER_OFF_TIME_MS=3
-DMBED_CONF_ESP8266_POWER_ON_POLARITY=0
-DMBED_CONF_ESP8266_POWER_ON_TIME_MS=3
-DMBED_CONF_ESP8266_PROVIDE_DEFAULT=0
-DMBED_CONF_ESP8266_SERIAL_BAUDRATE=115200
-DMBED_CONF_ESP8266_SNTP_ENABLE=0
-DMBED_CONF_ESP8266_SNTP_SERVER0=""
-DMBED_CONF_ESP8266_SNTP_SERVER1=""
-DMBED_CONF_ESP8266_SNTP_SERVER2=""
-DMBED_CONF_ESP8266_SNTP_TIMEZONE=0
-DMBED_CONF_ESP8266_SOCKET_BUFSIZE=8192
-DMBED_CONF_EVENTS_PRESENT=1
-DMBED_CONF_EVENTS_SHARED_DISPATCH_FROM_APPLICATION=0
-DMBED_CONF_EVENTS_SHARED_EVENTSIZE=768
-DMBED_CONF_EVENTS_SHARED_HIGHPRIO_EVENTSIZE=256
-DMBED_CONF_EVENTS_SHARED_HIGHPRIO_STACKSIZE=1024
-DMBED_CONF_EVENTS_SHARED_STACKSIZE=2048
-DMBED_CONF_EVENTS_USE_LOWPOWER_TIMER_TICKER=0
-DMBED_CONF_FAT_CHAN_FFS_DBG=0
-DMBED_CONF_FAT_CHAN_FF_CODE_PAGE=437
-DMBED_CONF_FAT_CHAN_FF_FS_EXFAT=0
-DMBED_CONF_FAT_CHAN_FF_FS_HEAPBUF=1
-DMBED_CONF_FAT_CHAN_FF_FS_LOCK=0
-DMBED_CONF_FAT_CHAN_FF_FS_MINIMIZE=0
-DMBED_CONF_FAT_CHAN_FF_FS_NOFSINFO=0
-DMBED_CONF_FAT_CHAN_FF_FS_NORTC=0
-DMBED_CONF_FAT_CHAN_FF_FS_READONLY=0
-DMBED_CONF_FAT_CHAN_FF_FS_REENTRANT=0
-DMBED_CONF_FAT_CHAN_FF_FS_RPATH=1
-DMBED_CONF_FAT_CHAN_FF_FS_TIMEOUT=1000
-DMBED_CONF_FAT_CHAN_FF_FS_TINY=1
-DMBED_CONF_FAT_CHAN_FF_LFN_BUF=255
-DMBED_CONF_FAT_CHAN_FF_LFN_UNICODE=0
-DMBED_CONF_FAT_CHAN_FF_MAX_LFN=255                                                                                                                                                                                                 [408/9004]
-DMBED_CONF_FAT_CHAN_FF_MAX_SS=4096
-DMBED_CONF_FAT_CHAN_FF_MIN_SS=512
-DMBED_CONF_FAT_CHAN_FF_MULTI_PARTITION=0
-DMBED_CONF_FAT_CHAN_FF_NORTC_MDAY=1
-DMBED_CONF_FAT_CHAN_FF_NORTC_MON=1
-DMBED_CONF_FAT_CHAN_FF_NORTC_YEAR=2017
-DMBED_CONF_FAT_CHAN_FF_SFN_BUF=12
-DMBED_CONF_FAT_CHAN_FF_STRF_ENCODE=3
-DMBED_CONF_FAT_CHAN_FF_STR_VOLUME_ID=0
-DMBED_CONF_FAT_CHAN_FF_SYNC_T=HANDLE
-DMBED_CONF_FAT_CHAN_FF_USE_CHMOD=0
-DMBED_CONF_FAT_CHAN_FF_USE_EXPAND=0
-DMBED_CONF_FAT_CHAN_FF_USE_FASTSEEK=0
-DMBED_CONF_FAT_CHAN_FF_USE_FIND=0
-DMBED_CONF_FAT_CHAN_FF_USE_FORWARD=0
-DMBED_CONF_FAT_CHAN_FF_USE_LABEL=0
-DMBED_CONF_FAT_CHAN_FF_USE_LFN=3
-DMBED_CONF_FAT_CHAN_FF_USE_MKFS=1
-DMBED_CONF_FAT_CHAN_FF_USE_STRFUNC=0
-DMBED_CONF_FAT_CHAN_FF_USE_TRIM=1
-DMBED_CONF_FAT_CHAN_FF_VOLUMES=4
-DMBED_CONF_FAT_CHAN_FF_VOLUME_STRS="RAM","NAND","CF","SD","SD2","USB","USB2","USB3"
-DMBED_CONF_FAT_CHAN_FLUSH_ON_NEW_CLUSTER=0
-DMBED_CONF_FAT_CHAN_FLUSH_ON_NEW_SECTOR=1
-DMBED_CONF_FILESYSTEM_PRESENT=1
-DMBED_CONF_FLASHIAP_BLOCK_DEVICE_BASE_ADDRESS=0xFFFFFFFF
-DMBED_CONF_FLASHIAP_BLOCK_DEVICE_SIZE=0
-DMBED_CONF_GEMALTO_CINTERION_BAUDRATE=115200
-DMBED_CONF_GEMALTO_CINTERION_PROVIDE_DEFAULT=0
-DMBED_CONF_GENERIC_AT3GPP_BAUDRATE=115200
-DMBED_CONF_GENERIC_AT3GPP_PROVIDE_DEFAULT=0
-DMBED_CONF_KINETIS_EMAC_RX_RING_LEN=2
-DMBED_CONF_KINETIS_EMAC_TX_RING_LEN=1
-DMBED_CONF_LORA_ADR_ON=1
"-DMBED_CONF_LORA_APPLICATION_EUI={0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}"
"-DMBED_CONF_LORA_APPLICATION_KEY={0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}"
"-DMBED_CONF_LORA_APPSKEY={0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}"
-DMBED_CONF_LORA_APP_PORT=15
-DMBED_CONF_LORA_AUTOMATIC_UPLINK_MESSAGE=1
-DMBED_CONF_LORA_DEVICE_ADDRESS=0x00000000
"-DMBED_CONF_LORA_DEVICE_EUI={0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}"
-DMBED_CONF_LORA_DOWNLINK_PREAMBLE_LENGTH=5
-DMBED_CONF_LORA_DUTY_CYCLE_ON=1
-DMBED_CONF_LORA_DUTY_CYCLE_ON_JOIN=1
"-DMBED_CONF_LORA_FSB_MASK={0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0x00FF}"
"-DMBED_CONF_LORA_FSB_MASK_CHINA={0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF}"
-DMBED_CONF_LORA_LBT_ON=0
-DMBED_CONF_LORA_MAX_SYS_RX_ERROR=5
-DMBED_CONF_LORA_NB_TRIALS=12
"-DMBED_CONF_LORA_NWKSKEY={0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}"
-DMBED_CONF_LORA_OVER_THE_AIR_ACTIVATION=1
-DMBED_CONF_LORA_PHY=EU868
-DMBED_CONF_LORA_PUBLIC_NETWORK=1
-DMBED_CONF_LORA_TX_MAX_SIZE=64
-DMBED_CONF_LORA_UPLINK_PREAMBLE_LENGTH=8
-DMBED_CONF_LORA_WAKEUP_TIME=5
-DMBED_CONF_LWIP_ADDR_TIMEOUT=5
-DMBED_CONF_LWIP_ADDR_TIMEOUT_MODE=1
-DMBED_CONF_LWIP_DEBUG_ENABLED=0
-DMBED_CONF_LWIP_DEFAULT_THREAD_STACKSIZE=512
-DMBED_CONF_LWIP_DHCP_TIMEOUT=60
-DMBED_CONF_LWIP_ENABLE_PPP_TRACE=0                                                                                                                                                                                                 [346/9004]
-DMBED_CONF_LWIP_ETHERNET_ENABLED=1
-DMBED_CONF_LWIP_IPV4_ENABLED=1
-DMBED_CONF_LWIP_IPV6_ENABLED=0
-DMBED_CONF_LWIP_IP_VER_PREF=4
-DMBED_CONF_LWIP_L3IP_ENABLED=0
-DMBED_CONF_LWIP_MBOX_SIZE=8
-DMBED_CONF_LWIP_MEMP_NUM_TCPIP_MSG_INPKT=8
-DMBED_CONF_LWIP_MEMP_NUM_TCP_SEG=16
-DMBED_CONF_LWIP_MEM_SIZE=33270
-DMBED_CONF_LWIP_NUM_NETBUF=8
-DMBED_CONF_LWIP_NUM_PBUF=8
-DMBED_CONF_LWIP_PBUF_POOL_SIZE=5
-DMBED_CONF_LWIP_PPP_ENABLED=0
-DMBED_CONF_LWIP_PPP_IPV4_ENABLED=0
-DMBED_CONF_LWIP_PPP_IPV6_ENABLED=0
-DMBED_CONF_LWIP_PPP_THREAD_STACKSIZE=768
-DMBED_CONF_LWIP_PRESENT=1
-DMBED_CONF_LWIP_RAW_SOCKET_ENABLED=0
-DMBED_CONF_LWIP_SOCKET_MAX=4
-DMBED_CONF_LWIP_TCPIP_THREAD_PRIORITY=osPriorityNormal
-DMBED_CONF_LWIP_TCPIP_THREAD_STACKSIZE=1200
-DMBED_CONF_LWIP_TCP_CLOSE_TIMEOUT=1000
-DMBED_CONF_LWIP_TCP_ENABLED=1
-DMBED_CONF_LWIP_TCP_MAXRTX=6
-DMBED_CONF_LWIP_TCP_MSS=536
-DMBED_CONF_LWIP_TCP_SERVER_MAX=4
"-DMBED_CONF_LWIP_TCP_SND_BUF=(2 * TCP_MSS)"
-DMBED_CONF_LWIP_TCP_SOCKET_MAX=4
-DMBED_CONF_LWIP_TCP_SYNMAXRTX=6
"-DMBED_CONF_LWIP_TCP_WND=(4 * TCP_MSS)"
-DMBED_CONF_LWIP_UDP_SOCKET_MAX=4
-DMBED_CONF_LWIP_USE_MBED_TRACE=0
-DMBED_CONF_MBED_MESH_API_6LOWPAN_ND_CHANNEL=0
-DMBED_CONF_MBED_MESH_API_6LOWPAN_ND_CHANNEL_MASK=0x7fff800
-DMBED_CONF_MBED_MESH_API_6LOWPAN_ND_CHANNEL_PAGE=0
-DMBED_CONF_MBED_MESH_API_6LOWPAN_ND_DEVICE_TYPE=NET_6LOWPAN_ROUTER
-DMBED_CONF_MBED_MESH_API_6LOWPAN_ND_PANID_FILTER=0xffff
"-DMBED_CONF_MBED_MESH_API_6LOWPAN_ND_PSK_KEY={0xa0, 0xa1, 0xa2, 0xa3, 0xa4, 0xa5, 0xa6, 0xa7, 0xa8, 0xa9, 0xaa, 0xab, 0xac, 0xad, 0xae, 0xaf}"
-DMBED_CONF_MBED_MESH_API_6LOWPAN_ND_PSK_KEY_ID=1
-DMBED_CONF_MBED_MESH_API_6LOWPAN_ND_SECURITY_MODE=NONE
-DMBED_CONF_MBED_MESH_API_6LOWPAN_ND_SEC_LEVEL=5
-DMBED_CONF_MBED_MESH_API_HEAP_SIZE=32500
-DMBED_CONF_MBED_MESH_API_HEAP_STAT_INFO=NULL
-DMBED_CONF_MBED_MESH_API_MAC_NEIGH_TABLE_SIZE=32
-DMBED_CONF_MBED_MESH_API_THREAD_CONFIG_CHANNEL=22
-DMBED_CONF_MBED_MESH_API_THREAD_CONFIG_CHANNEL_MASK=0x7fff800
-DMBED_CONF_MBED_MESH_API_THREAD_CONFIG_CHANNEL_PAGE=0
-DMBED_CONF_MBED_MESH_API_THREAD_CONFIG_COMMISSIONING_DATASET_TIMESTAMP=0x10000
"-DMBED_CONF_MBED_MESH_API_THREAD_CONFIG_EXTENDED_PANID={0xf1, 0xb5, 0xa1, 0xb2,0xc4, 0xd5, 0xa1, 0xbd }"
"-DMBED_CONF_MBED_MESH_API_THREAD_CONFIG_ML_PREFIX={0xfd, 0x0, 0x0d, 0xb8, 0x0, 0x0, 0x0, 0x0}"
-DMBED_CONF_MBED_MESH_API_THREAD_CONFIG_NETWORK_NAME="Thread Network"
-DMBED_CONF_MBED_MESH_API_THREAD_CONFIG_PANID=0x0700
"-DMBED_CONF_MBED_MESH_API_THREAD_CONFIG_PSKC={0xc8, 0xa6, 0x2e, 0xae, 0xf3, 0x68, 0xf3, 0x46, 0xa9, 0x9e, 0x57, 0x85, 0x98, 0x9d, 0x1c, 0xd0}"
-DMBED_CONF_MBED_MESH_API_THREAD_DEVICE_TYPE=MESH_DEVICE_TYPE_THREAD_ROUTER
"-DMBED_CONF_MBED_MESH_API_THREAD_MASTER_KEY={0x10, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff}"
-DMBED_CONF_MBED_MESH_API_THREAD_PSKD="ABCDEFGH"
-DMBED_CONF_MBED_MESH_API_THREAD_SECURITY_POLICY=255
-DMBED_CONF_MBED_MESH_API_THREAD_USE_STATIC_LINK_CONFIG=1
-DMBED_CONF_MBED_MESH_API_USE_MALLOC_FOR_HEAP=0
-DMBED_CONF_MBED_MESH_API_WISUN_BC_CHANNEL_FUNCTION=255
-DMBED_CONF_MBED_MESH_API_WISUN_BC_DWELL_INTERVAL=0
-DMBED_CONF_MBED_MESH_API_WISUN_BC_FIXED_CHANNEL=65535                                                                                                                                                                              [284/9004]
-DMBED_CONF_MBED_MESH_API_WISUN_BC_INTERVAL=0
-DMBED_CONF_MBED_MESH_API_WISUN_DEVICE_TYPE=MESH_DEVICE_TYPE_WISUN_ROUTER
-DMBED_CONF_MBED_MESH_API_WISUN_NETWORK_NAME="Wi-SUN Network"
-DMBED_CONF_MBED_MESH_API_WISUN_OPERATING_CLASS=255
-DMBED_CONF_MBED_MESH_API_WISUN_OPERATING_MODE=255
-DMBED_CONF_MBED_MESH_API_WISUN_REGULATORY_DOMAIN=3
-DMBED_CONF_MBED_MESH_API_WISUN_UC_CHANNEL_FUNCTION=255
-DMBED_CONF_MBED_MESH_API_WISUN_UC_DWELL_INTERVAL=255
-DMBED_CONF_MBED_MESH_API_WISUN_UC_FIXED_CHANNEL=65535
-DMBED_CONF_MCR20A_PROVIDE_DEFAULT=0
-DMBED_CONF_NANOSTACK_CONFIGURATION=nanostack_full
-DMBED_CONF_NANOSTACK_HAL_CRITICAL_SECTION_USABLE_FROM_INTERRUPT=0
-DMBED_CONF_NANOSTACK_HAL_EVENT_LOOP_DISPATCH_FROM_APPLICATION=0
-DMBED_CONF_NANOSTACK_HAL_EVENT_LOOP_THREAD_STACK_SIZE=6144
-DMBED_CONF_NANOSTACK_HAL_EVENT_LOOP_USE_MBED_EVENTS=0
-DMBED_CONF_NANOSTACK_HAL_KVSTORE_PATH="/kv/"
-DMBED_CONF_NANOSTACK_HAL_USE_KVSTORE=0
-DMBED_CONF_NSAPI_DEFAULT_MESH_TYPE=THREAD
-DMBED_CONF_NSAPI_DEFAULT_STACK=LWIP
-DMBED_CONF_NSAPI_DEFAULT_WIFI_SECURITY=NONE
-DMBED_CONF_NSAPI_DNS_ADDRESSES_LIMIT=10
-DMBED_CONF_NSAPI_DNS_CACHE_SIZE=3
-DMBED_CONF_NSAPI_DNS_RESPONSE_WAIT_TIME=10000
-DMBED_CONF_NSAPI_DNS_RETRIES=1
-DMBED_CONF_NSAPI_DNS_TOTAL_ATTEMPTS=10
-DMBED_CONF_NSAPI_PRESENT=1
-DMBED_CONF_NSAPI_SOCKET_STATS_ENABLED=0
-DMBED_CONF_NSAPI_SOCKET_STATS_MAX_COUNT=10
-DMBED_CONF_PLATFORM_CALLBACK_COMPARABLE=1
-DMBED_CONF_PLATFORM_CALLBACK_NONTRIVIAL=0
-DMBED_CONF_PLATFORM_CRASH_CAPTURE_ENABLED=1
-DMBED_CONF_PLATFORM_CTHUNK_COUNT_MAX=8
-DMBED_CONF_PLATFORM_DEFAULT_SERIAL_BAUD_RATE=9600
-DMBED_CONF_PLATFORM_ERROR_ALL_THREADS_INFO=0
-DMBED_CONF_PLATFORM_ERROR_FILENAME_CAPTURE_ENABLED=0
-DMBED_CONF_PLATFORM_ERROR_HIST_ENABLED=0
-DMBED_CONF_PLATFORM_ERROR_HIST_SIZE=4
-DMBED_CONF_PLATFORM_ERROR_REBOOT_MAX=1
-DMBED_CONF_PLATFORM_FATAL_ERROR_AUTO_REBOOT_ENABLED=1
-DMBED_CONF_PLATFORM_MAX_ERROR_FILENAME_LEN=16
-DMBED_CONF_PLATFORM_MINIMAL_PRINTF_ENABLE_64_BIT=1
-DMBED_CONF_PLATFORM_MINIMAL_PRINTF_ENABLE_FLOATING_POINT=0
-DMBED_CONF_PLATFORM_MINIMAL_PRINTF_SET_FLOATING_POINT_MAX_DECIMALS=6
-DMBED_CONF_PLATFORM_POLL_USE_LOWPOWER_TIMER=0
-DMBED_CONF_PLATFORM_STDIO_BAUD_RATE=9600
-DMBED_CONF_PLATFORM_STDIO_BUFFERED_SERIAL=0
-DMBED_CONF_PLATFORM_STDIO_CONVERT_NEWLINES=1
-DMBED_CONF_PLATFORM_STDIO_CONVERT_TTY_NEWLINES=1
-DMBED_CONF_PLATFORM_STDIO_FLUSH_AT_EXIT=1
-DMBED_CONF_PLATFORM_STDIO_MINIMAL_CONSOLE_ONLY=0
-DMBED_CONF_PLATFORM_USE_MPU=1
-DMBED_CONF_PPP_ENABLED=0
-DMBED_CONF_PPP_ENABLE_TRACE=0
-DMBED_CONF_PPP_IPV4_ENABLED=1
-DMBED_CONF_PPP_IPV6_ENABLED=0
-DMBED_CONF_PPP_MBED_EVENT_QUEUE=0
-DMBED_CONF_PPP_THREAD_STACKSIZE=816
-DMBED_CONF_QUECTEL_BC95_BAUDRATE=9600
-DMBED_CONF_QUECTEL_BC95_PROVIDE_DEFAULT=0
-DMBED_CONF_QUECTEL_BG96_BAUDRATE=115200
-DMBED_CONF_QUECTEL_BG96_PROVIDE_DEFAULT=0
-DMBED_CONF_QUECTEL_EC2X_BAUDRATE=115200                                                                                                                                                                                            [222/9004]
-DMBED_CONF_QUECTEL_EC2X_PROVIDE_DEFAULT=0
-DMBED_CONF_QUECTEL_EC2X_START_TIMEOUT=15000
-DMBED_CONF_QUECTEL_M26_BAUDRATE=115200
-DMBED_CONF_QUECTEL_M26_PROVIDE_DEFAULT=0
-DMBED_CONF_QUECTEL_UG96_BAUDRATE=115200
-DMBED_CONF_QUECTEL_UG96_PROVIDE_DEFAULT=0
-DMBED_CONF_RM1000_AT_BAUDRATE=230400
-DMBED_CONF_RM1000_AT_PROVIDE_DEFAULT=0
-DMBED_CONF_RTOS_API_PRESENT=1
-DMBED_CONF_RTOS_EVFLAGS_NUM=0
-DMBED_CONF_RTOS_IDLE_THREAD_STACK_SIZE=512
-DMBED_CONF_RTOS_IDLE_THREAD_STACK_SIZE_DEBUG_EXTRA=0
-DMBED_CONF_RTOS_IDLE_THREAD_STACK_SIZE_TICKLESS_EXTRA=256
-DMBED_CONF_RTOS_MAIN_THREAD_STACK_SIZE=4096
-DMBED_CONF_RTOS_MSGQUEUE_DATA_SIZE=0
-DMBED_CONF_RTOS_MSGQUEUE_NUM=0
-DMBED_CONF_RTOS_MUTEX_NUM=0
-DMBED_CONF_RTOS_PRESENT=1
-DMBED_CONF_RTOS_SEMAPHORE_NUM=0
-DMBED_CONF_RTOS_THREAD_NUM=0
-DMBED_CONF_RTOS_THREAD_STACK_SIZE=4096
-DMBED_CONF_RTOS_THREAD_USER_STACK_SIZE=0
-DMBED_CONF_RTOS_TIMER_NUM=0
-DMBED_CONF_RTOS_TIMER_THREAD_STACK_SIZE=768
-DMBED_CONF_S2LP_PROVIDE_DEFAULT=0
-DMBED_CONF_SARA4_PPP_BAUDRATE=115200
-DMBED_CONF_SARA4_PPP_PROVIDE_DEFAULT=0
-DMBED_CONF_SD_CMD0_IDLE_STATE_RETRIES=5
-DMBED_CONF_SD_CMD_TIMEOUT=10000
-DMBED_CONF_SD_CRC_ENABLED=0
-DMBED_CONF_SD_FSFAT_SDCARD_INSTALLED=1
-DMBED_CONF_SD_INIT_FREQUENCY=100000
-DMBED_CONF_SD_SPI_CLK=SPI_SCK
-DMBED_CONF_SD_SPI_CS=SPI_CS
-DMBED_CONF_SD_SPI_MISO=SPI_MISO
-DMBED_CONF_SD_SPI_MOSI=SPI_MOSI
-DMBED_CONF_SD_TEST_BUFFER=8192
-DMBED_CONF_SD_TRX_FREQUENCY=1000000
-DMBED_CONF_STORAGE_DEFAULT_KV=kv
-DMBED_CONF_STORAGE_FILESYSTEM_BLOCKDEVICE=default
-DMBED_CONF_STORAGE_FILESYSTEM_EXTERNAL_BASE_ADDRESS=0
-DMBED_CONF_STORAGE_FILESYSTEM_EXTERNAL_SIZE=0
-DMBED_CONF_STORAGE_FILESYSTEM_FILESYSTEM=default
-DMBED_CONF_STORAGE_FILESYSTEM_FOLDER_PATH=kvstore
-DMBED_CONF_STORAGE_FILESYSTEM_INTERNAL_BASE_ADDRESS=0
-DMBED_CONF_STORAGE_FILESYSTEM_MOUNT_POINT=kv
-DMBED_CONF_STORAGE_FILESYSTEM_NO_RBP_BLOCKDEVICE=default
-DMBED_CONF_STORAGE_FILESYSTEM_NO_RBP_EXTERNAL_BASE_ADDRESS=0
-DMBED_CONF_STORAGE_FILESYSTEM_NO_RBP_EXTERNAL_SIZE=0
-DMBED_CONF_STORAGE_FILESYSTEM_NO_RBP_FILESYSTEM=default
-DMBED_CONF_STORAGE_FILESYSTEM_NO_RBP_FOLDER_PATH=kvstore
-DMBED_CONF_STORAGE_FILESYSTEM_NO_RBP_MOUNT_POINT=kv
-DMBED_CONF_STORAGE_FILESYSTEM_RBP_INTERNAL_SIZE=0
-DMBED_CONF_STORAGE_STORAGE_TYPE=default
-DMBED_CONF_STORAGE_TDB_EXTERNAL_BLOCKDEVICE=default
-DMBED_CONF_STORAGE_TDB_EXTERNAL_EXTERNAL_BASE_ADDRESS=0
-DMBED_CONF_STORAGE_TDB_EXTERNAL_EXTERNAL_SIZE=0
-DMBED_CONF_STORAGE_TDB_EXTERNAL_INTERNAL_BASE_ADDRESS=0
-DMBED_CONF_STORAGE_TDB_EXTERNAL_NO_RBP_BLOCKDEVICE=default
-DMBED_CONF_STORAGE_TDB_EXTERNAL_NO_RBP_EXTERNAL_BASE_ADDRESS=0
-DMBED_CONF_STORAGE_TDB_EXTERNAL_NO_RBP_EXTERNAL_SIZE=0
-DMBED_CONF_STORAGE_TDB_EXTERNAL_RBP_INTERNAL_SIZE=0                                                                                                                                                                                [160/9004]
-DMBED_CONF_STORAGE_TDB_INTERNAL_INTERNAL_BASE_ADDRESS=0
-DMBED_CONF_STORAGE_TDB_INTERNAL_INTERNAL_SIZE=0
-DMBED_CONF_TARGET_BOOT_STACK_SIZE=0x400
-DMBED_CONF_TARGET_CONSOLE_UART=1
-DMBED_CONF_TARGET_DEEP_SLEEP_LATENCY=0
-DMBED_CONF_TARGET_DEFAULT_ADC_VREF=NAN
-DMBED_CONF_TARGET_INIT_US_TICKER_AT_BOOT=0
-DMBED_CONF_TARGET_MPU_ROM_END=0x0fffffff
-DMBED_CONF_TARGET_NETWORK_DEFAULT_INTERFACE_TYPE=ETHERNET
-DMBED_CONF_TARGET_TICKLESS_FROM_US_TICKER=0
-DMBED_CONF_TARGET_XIP_ENABLE=0
-DMBED_CONF_TELIT_HE910_BAUDRATE=115200
-DMBED_CONF_TELIT_HE910_PROVIDE_DEFAULT=0
-DMBED_CONF_TELIT_ME310_BAUDRATE=115200
-DMBED_CONF_TELIT_ME310_PROVIDE_DEFAULT=0
-DMBED_CONF_TELIT_ME910_BAUDRATE=115200
-DMBED_CONF_TELIT_ME910_PROVIDE_DEFAULT=0
-DMBED_CONF_UBLOX_AT_BAUDRATE=115200
-DMBED_CONF_UBLOX_AT_PROVIDE_DEFAULT=0
-DMBED_CONF_UBLOX_N2XX_BAUDRATE=9600
-DMBED_CONF_UBLOX_N2XX_PROVIDE_DEFAULT=0
-DMBED_CONF_UBLOX_PPP_BAUDRATE=115200
-DMBED_CONF_UBLOX_PPP_PROVIDE_DEFAULT=0
-DMBED_CRC_TABLE_SIZE=16
-DMBED_LFS2_BLOCK_CYCLES=1024
-DMBED_LFS2_BLOCK_SIZE=512
-DMBED_LFS2_CACHE_SIZE=64
-DMBED_LFS2_ENABLE_INFO=0
-DMBED_LFS2_INTRINSICS=1
-DMBED_LFS2_LOOKAHEAD_SIZE=64
-DMBED_LFS_BLOCK_SIZE=512
-DMBED_LFS_ENABLE_INFO=0
-DMBED_LFS_INTRINSICS=1
-DMBED_LFS_LOOKAHEAD=512
-DMBED_LFS_PROG_SIZE=64
-DMBED_LFS_READ_SIZE=64
-DMBED_STACK_DUMP_ENABLED=0
-DMEM_ALLOC=malloc
-DMEM_FREE=free
-DPPP_DEBUG=0

# macros
-DMBEDTLS_CIPHER_MODE_CTR
"-DNSAPI_PPP_AVAILABLE=(MBED_CONF_PPP_ENABLED || MBED_CONF_LWIP_PPP_ENABLED)"
-DNS_USE_EXTERNAL_MBED_TLS
-DUNITY_INCLUDE_CONFIG_H
-D_RTE_
)⏎
(mbed-tools) robwal02@C02X70Z4JHD5 ~/p/m/p/mbed-os-example-blinky (feature-cmake)> mkdir build && cd build
(mbed-tools) robwal02@C02X70Z4JHD5 ~/p/m/p/m/build (feature-cmake)> cmake -GNinja ..
-- The C compiler identification is GNU 9.2.1
-- The CXX compiler identification is GNU 9.2.1
-- The ASM compiler identification is GNU
-- Found assembler: /usr/local/bin/arm-none-eabi-gcc
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - failed
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - failed
-- Detecting CXX compile features
-- Detecting CXX compile features - done                                                                                                                                                                                             [98/9004]
-- Configuring done
-- Generating done
-- Build files have been written to: /Users/robwal02/projects/mbed/programs/mbed-os-example-blinky/build
(mbed-tools) robwal02@C02X70Z4JHD5 ~/p/m/p/m/build (feature-cmake)> ninja
[86/776] Building C object CMakeFiles/mbed-os.dir/mbed-os/features/nanostack/sal-stack-nanostack/source/Common_Protocols/tcp.c.obj
../mbed-os/features/nanostack/sal-stack-nanostack/source/Common_Protocols/tcp.c:86:20: warning: 'trace_tcp_flags' defined but not used [-Wunused-function]
   86 | static const char *trace_tcp_flags(uint16_t flags)
      |                    ^~~~~~~~~~~~~~~
[150/776] Building C object CMakeFiles/mbed-os.dir/mbed-os/features/nanostack/sal-stack-nanostack/source/Security/protocols/tls_sec_prot/tls_sec_prot.c.obj
../mbed-os/features/nanostack/sal-stack-nanostack/source/Security/protocols/tls_sec_prot/tls_sec_prot.c: In function 'server_tls_sec_prot_state_machine':
../mbed-os/features/nanostack/sal-stack-nanostack/source/Security/protocols/tls_sec_prot/tls_sec_prot.c:510:22: warning: unused variable 'remote_eui_64' [-Wunused-variable]
  510 |             uint8_t *remote_eui_64 = sec_prot_remote_eui_64_addr_get(prot);
      |                      ^~~~~~~~~~~~~
[235/776] Building CXX object CMakeFiles/mbed-os.dir/mbed-os/features/netsocket/emac-drivers/TARGET_Freescale_EMAC/kinetis_emac.cpp.obj
../mbed-os/features/netsocket/emac-drivers/TARGET_Freescale_EMAC/kinetis_emac.cpp: In member function 'virtual bool Kinetis_EMAC::link_out(emac_mem_buf_t*)':
../mbed-os/features/netsocket/emac-drivers/TARGET_Freescale_EMAC/kinetis_emac.cpp:412:41: warning: 'bool rtos::Semaphore::try_acquire_for(uint32_t)' is deprecated: Pass a chrono duration, not an integer millisecond count. For example use
`5s` rather than `5000`. [since mbed-os-6.0.0] [-Wdeprecated-declarations]
  412 |     if (!xTXDCountSem.try_acquire_for(10)) {
      |                                         ^
In file included from ../mbed-os/features/netsocket/emac-drivers/TARGET_Freescale_EMAC/kinetis_emac.h:21,
                 from ../mbed-os/features/netsocket/emac-drivers/TARGET_Freescale_EMAC/kinetis_emac.cpp:48:
../mbed-os/rtos/include/rtos/Semaphore.h:89:10: note: declared here
   89 |     bool try_acquire_for(uint32_t millisec);
      |          ^~~~~~~~~~~~~~~
[289/776] Building C object CMakeFiles/mbed-os.dir/mbed-os/platform/source/mbed_error.c.obj
../mbed-os/platform/source/mbed_error.c:119:13: warning: 'mbed_error_is_handler' defined but not used [-Wunused-function]
  119 | static bool mbed_error_is_handler(const mbed_error_ctx *ctx)
      |             ^~~~~~~~~~~~~~~~~~~~~
[300/776] Building C object CMakeFiles/mbed-os.dir/mbed-os/rtos/source/TARGET_CORTEX/mbed_rtx_handlers.c.obj
../mbed-os/rtos/source/TARGET_CORTEX/mbed_rtx_handlers.c:87:20: warning: 'error_msg' defined but not used [-Wunused-function]
   87 | static const char *error_msg(int32_t status)
      |                    ^~~~~~~~~
[307/776] Building C object CMakeFiles/mbed-os.dir/mbed-os/rtos/source/TARGET_CORTEX/rtx5/RTX/Source/rtx_kernel.c.obj
../mbed-os/rtos/source/TARGET_CORTEX/rtx5/RTX/Source/rtx_kernel.c: In function 'svcRtxKernelInitialize':
../mbed-os/rtos/source/TARGET_CORTEX/rtx5/RTX/Source/rtx_kernel.c:93:3: warning: 'memset' offset [17, 164] from the object at 'osRtxInfo' is out of the bounds of referenced subobject 'kernel' with type 'struct <anonymous>' at offset 8 [-W
array-bounds]
   93 |   memset(&osRtxInfo.kernel, 0, sizeof(osRtxInfo) - offsetof(osRtxInfo_t, kernel));
      |   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
[329/776] Building CXX object CMakeFiles/mbed-os.dir/mbed-os/rtos/source/ThisThread.cpp.obj
../mbed-os/rtos/source/ThisThread.cpp: In function 'void rtos::ThisThread::sleep_for(rtos::Kernel::Clock::duration_u32)':
../mbed-os/rtos/source/ThisThread.cpp:224:16: warning: unused variable 'status' [-Wunused-variable]
  224 |     osStatus_t status = osDelay(rel_time.count());
      |                ^~~~~~
../mbed-os/rtos/source/ThisThread.cpp: In function 'void rtos::ThisThread::sleep_until(rtos::Kernel::Clock::time_point)':
../mbed-os/rtos/source/ThisThread.cpp:243:24: warning: unused variable 'status' [-Wunused-variable]
  243 |             osStatus_t status = osDelay(wait_for_u32_max.count());
      |                        ^~~~~~
../mbed-os/rtos/source/ThisThread.cpp:247:24: warning: unused variable 'status' [-Wunused-variable]
  247 |             osStatus_t status = osDelay((abs_time - now).count());
      |                        ^~~~~~
[468/776] Building CXX object CMakeFiles/mbed-os.dir/mbed-os/connectivity/cellular/source/framework/device/CellularContext.cpp.obj
../mbed-os/connectivity/cellular/source/framework/device/CellularContext.cpp: In member function 'mbed::CellularContext::pdp_type_t mbed::CellularContext::string_to_pdp_type(const char*)':
../mbed-os/connectivity/cellular/source/framework/device/CellularContext.cpp:121:20: warning: comparison of integer expressions of different signedness: 'int' and 'size_t' {aka 'unsigned int'} [-Wsign-compare]
  121 |                len == strlen(get_nonip_context_type_str()) &&
      |                ~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
[475/776] Building CXX object CMakeFiles/mbed-os.dir/mbed-os/connectivity/drivers/802.15.4_RF/atmel-rf-driver/source/NanostackRfPhyAT86RF215.cpp.obj
../mbed-os/connectivity/drivers/802.15.4_RF/atmel-rf-driver/source/NanostackRfPhyAT86RF215.cpp: In function 'uint32_t rf_get_timestamp()':
../mbed-os/connectivity/drivers/802.15.4_RF/atmel-rf-driver/source/NanostackRfPhyAT86RF215.cpp:195:43: warning: 'int mbed::TimerBase::read_us() const' is deprecated: Use the Chrono-based elapsed_time method.  If integer microseconds are n
eeded, you can use `elapsed_time().count()` [since mbed-os-6.0.0] [-Wdeprecated-declarations]
  195 |     return (uint32_t)rf->tx_timer.read_us();
      |                                           ^
In file included from ../mbed-os/connectivity/drivers/802.15.4_RF/atmel-rf-driver/source/NanostackRfPhyAT86RF215.cpp:30:                                                                                                             [36/9004]
../mbed-os/drivers/Timer.h:93:9: note: declared here
   93 |     int read_us() const;
      |         ^~~~~~~
../mbed-os/connectivity/drivers/802.15.4_RF/atmel-rf-driver/source/NanostackRfPhyAT86RF215.cpp: In function 'int8_t rf_start_csma_ca(uint8_t*, uint16_t, uint8_t, data_protocol_e)':
../mbed-os/connectivity/drivers/802.15.4_RF/atmel-rf-driver/source/NanostackRfPhyAT86RF215.cpp:542:74: warning: 'void mbed::TickerBase::attach_us(mbed::Callback<void()>, us_timestamp_t)' is deprecated: Pass a chrono duration, not an integ
er microsecond count. For example use `10ms` rather than `10000`. [since mbed-os-6.0.0] [-Wdeprecated-declarations]
  542 |             rf->cca_timer.attach_us(rf_csma_ca_timer_signal, backoff_time);
      |                                                                          ^
In file included from ../mbed-os/drivers/Timeout.h:21,
                 from ../mbed-os/connectivity/drivers/802.15.4_RF/atmel-rf-driver/source/NanostackRfPhyAT86RF215.cpp:31:
../mbed-os/./drivers/Ticker.h:110:10: note: declared here
  110 |     void attach_us(Callback<void()> func, us_timestamp_t t);
      |          ^~~~~~~~~
../mbed-os/connectivity/drivers/802.15.4_RF/atmel-rf-driver/source/NanostackRfPhyAT86RF215.cpp:549:55: warning: 'void mbed::TickerBase::attach_us(mbed::Callback<void()>, us_timestamp_t)' is deprecated: Pass a chrono duration, not an integ
er microsecond count. For example use `10ms` rather than `10000`. [since mbed-os-6.0.0] [-Wdeprecated-declarations]
  549 |     rf->cca_timer.attach_us(rf_csma_ca_timer_signal, 1);
      |                                                       ^
In file included from ../mbed-os/drivers/Timeout.h:21,
                 from ../mbed-os/connectivity/drivers/802.15.4_RF/atmel-rf-driver/source/NanostackRfPhyAT86RF215.cpp:31:
../mbed-os/./drivers/Ticker.h:110:10: note: declared here
  110 |     void attach_us(Callback<void()> func, us_timestamp_t t);
      |          ^~~~~~~~~
../mbed-os/connectivity/drivers/802.15.4_RF/atmel-rf-driver/source/NanostackRfPhyAT86RF215.cpp: In function 'void rf_handle_cca_ed_done()':
../mbed-os/connectivity/drivers/802.15.4_RF/atmel-rf-driver/source/NanostackRfPhyAT86RF215.cpp:587:74: warning: 'void mbed::TickerBase::attach_us(mbed::Callback<void()>, us_timestamp_t)' is deprecated: Pass a chrono duration, not an integ
er microsecond count. For example use `10ms` rather than `10000`. [since mbed-os-6.0.0] [-Wdeprecated-declarations]
  587 |             rf->cca_timer.attach_us(rf_csma_ca_timer_signal, backoff_time);
      |                                                                          ^
In file included from ../mbed-os/drivers/Timeout.h:21,
                 from ../mbed-os/connectivity/drivers/802.15.4_RF/atmel-rf-driver/source/NanostackRfPhyAT86RF215.cpp:31:
../mbed-os/./drivers/Ticker.h:110:10: note: declared here
  110 |     void attach_us(Callback<void()> func, us_timestamp_t t);
      |          ^~~~~~~~~
../mbed-os/connectivity/drivers/802.15.4_RF/atmel-rf-driver/source/NanostackRfPhyAT86RF215.cpp: In function 'uint32_t rf_backup_timer_start(uint16_t, uint32_t)':
../mbed-os/connectivity/drivers/802.15.4_RF/atmel-rf-driver/source/NanostackRfPhyAT86RF215.cpp:963:60: warning: 'void mbed::TickerBase::attach_us(mbed::Callback<void()>, us_timestamp_t)' is deprecated: Pass a chrono duration, not an integ
er microsecond count. For example use `10ms` rather than `10000`. [since mbed-os-6.0.0] [-Wdeprecated-declarations]
  963 |     rf->cal_timer.attach_us(rf_backup_timer_signal, time_us);
      |                                                            ^
In file included from ../mbed-os/drivers/Timeout.h:21,
                 from ../mbed-os/connectivity/drivers/802.15.4_RF/atmel-rf-driver/source/NanostackRfPhyAT86RF215.cpp:31:
../mbed-os/./drivers/Ticker.h:110:10: note: declared here
  110 |     void attach_us(Callback<void()> func, us_timestamp_t t);
      |          ^~~~~~~~~
[545/776] Building CXX object CMakeFiles/mbed-os.dir/mbed-os/connectivity/netsocket/source/nsapi_dns.cpp.obj
In file included from ../mbed-os/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K64F/drivers/fsl_dspi.h:11,
                 from ../mbed-os/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K64F/drivers/fsl_dspi_edma.h:11,
                 from ../mbed-os/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/api/objects.h:24,
                 from ../mbed-os/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K64F/TARGET_FRDM/device.h:37,
                 from ../mbed-os/./hal/ticker_api.h:25,
                 from ../mbed-os/connectivity/netsocket/include/netsocket/SocketStats.h:24,
                 from ../mbed-os/connectivity/netsocket/include/netsocket/InternetSocket.h:30,
                 from ../mbed-os/connectivity/netsocket/include/netsocket/UDPSocket.h:23,
                 from ../mbed-os/connectivity/netsocket/source/nsapi_dns.cpp:22:
../mbed-os/connectivity/netsocket/source/nsapi_dns.cpp: In function 'nsapi_size_or_error_t nsapi_dns_query_multiple(NetworkStack*, const char*, nsapi_addr_t*, unsigned int, const char*, nsapi_version_t)':
../mbed-os/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K64F/drivers/fsl_common.h:145:24: warning: comparison of integer expressions of different signedness: 'int' and 'unsigned int' [-Wsign-compare]
  145 | #define MIN(a, b) ((a) < (b) ? (a) : (b))
      |                    ~~~~^~~~~
../mbed-os/connectivity/netsocket/source/nsapi_dns.cpp:491:30: note: in expansion of macro 'MIN'
  491 |         for (int i = 0;  i < MIN(cached, addr_count); i++) {
      |                              ^~~
../mbed-os/connectivity/netsocket/source/nsapi_dns.cpp:491:28: warning: comparison of integer expressions of different signedness: 'int' and 'unsigned int' [-Wsign-compare]
  491 |         for (int i = 0;  i < MIN(cached, addr_count); i++) {
In file included from ../mbed-os/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K64F/drivers/fsl_dspi.h:11,
                 from ../mbed-os/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K64F/drivers/fsl_dspi_edma.h:11,
                 from ../mbed-os/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/api/objects.h:24,
                 from ../mbed-os/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K64F/TARGET_FRDM/device.h:37,
                 from ../mbed-os/./hal/ticker_api.h:25,
                 from ../mbed-os/connectivity/netsocket/include/netsocket/SocketStats.h:24,
                 from ../mbed-os/connectivity/netsocket/include/netsocket/InternetSocket.h:30,
                 from ../mbed-os/connectivity/netsocket/include/netsocket/UDPSocket.h:23,
                 from ../mbed-os/connectivity/netsocket/source/nsapi_dns.cpp:22:
../mbed-os/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K64F/drivers/fsl_common.h:145:24: warning: comparison of integer expressions of different signedness: 'int' and 'unsigned int' [-Wsign-compare]
  145 | #define MIN(a, b) ((a) < (b) ? (a) : (b))
      |                    ~~~~^~~~~
../mbed-os/connectivity/netsocket/source/nsapi_dns.cpp:495:16: note: in expansion of macro 'MIN'
  495 |         return MIN(cached, addr_count);
      |                ^~~
[552/776] Building CXX object CMakeFiles/mbed-os.dir/mbed-os/drivers/source/SFDP.cpp.obj
../mbed-os/drivers/source/SFDP.cpp: In function 'int mbed::sfdp_iterate_next_largest_erase_type(uint8_t&, int, int, int, const mbed::sfdp_smptbl_info&)':
../mbed-os/drivers/source/SFDP.cpp:409:22: warning: comparison of integer expressions of different signedness: 'long long unsigned int' and 'int' [-Wsign-compare]
  408 |                     ((smptbl.region_high_boundary[region] - offset)
      |                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  409 |                      > (int)(smptbl.erase_type_size_arr[largest_erase_type]))) {
      |                      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
[759/776] Building C object CMakeFiles/mbed-os.dir/mbed-os/features/nanostack/mbed-mesh-api/source/thread_tasklet.c.obj
../mbed-os/features/nanostack/mbed-mesh-api/source/thread_tasklet.c: In function 'thread_tasklet_configure_and_connect_to_network':
../mbed-os/features/nanostack/mbed-mesh-api/source/thread_tasklet.c:327:13: warning: unused variable 'ret' [-Wunused-variable]
  327 |         int ret = thread_tasklet_device_pskd_set(PSKd);
      |             ^~~
[775/776] Building CXX object CMakeFiles/mbed-os.dir/mbed-os/features/nanostack/nanostack-interface/Nanostack.cpp.obj
../mbed-os/features/nanostack/nanostack-interface/Nanostack.cpp: In member function 'void NanostackSocket::close()':
../mbed-os/features/nanostack/nanostack-interface/Nanostack.cpp:247:23: warning: unused variable 'ret' [-Wunused-variable]
  247 |         nsapi_error_t ret = socket_close(socket_id);
      |                       ^~~
[776/776] Linking CXX executable app
-- built: /Users/robwal02/projects/mbed/programs/mbed-os-example-blinky/build/app.bin
-- built: /Users/robwal02/projects/mbed/programs/mbed-os-example-blinky/build/app.hex
```