### PR TITLE
Send codecov notifications after all results uploaded

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -11,9 +11,9 @@ coverage:
         # basic
         target: auto
         threshold: 2%
-        base: auto 
+        base: auto
         # advanced
-        branches: 
+        branches:
           - master
         if_not_found: success
         if_ci_failed: error

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,5 +1,7 @@
 codecov:
   require_ci_to_pass: yes
+  notify:
+    after_n_builds: 3
 
 coverage:
   precision: 2

--- a/news/20200729200627.misc
+++ b/news/20200729200627.misc
@@ -1,0 +1,1 @@
+Tell codecov to only report coverage after results from all platforms have been uploaded


### PR DESCRIPTION
### Description

<!--
Please add any detail or context that would be useful to a reviewer.
-->
We don't want codecov to notify until results for all platforms have been uploaded and the reports merged.


### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [ ]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
