### PR TITLE
Ensure correct exit code is returned when ToolsError is raised

### DIFF
--- a/news/20200729210710.bugfix
+++ b/news/20200729210710.bugfix
@@ -1,0 +1,1 @@
+Return an exit code of 1 when a ToolsError is raised

--- a/src/mbed_tools/cli/main.py
+++ b/src/mbed_tools/cli/main.py
@@ -4,16 +4,17 @@
 #
 """Main cli entry point."""
 import logging
-from pkg_resources import get_distribution
 
+from pkg_resources import get_distribution
 from typing import Union, Any
+
 import click
 
 from mbed_tools.lib.logging import set_log_level, MbedToolsHandler
 
 from mbed_tools.cli.configure import configure
-from mbed_tools.cli.list_connected_devices import list_connected_devices
 from mbed_tools.cli.env_cli import cli as env_cli
+from mbed_tools.cli.list_connected_devices import list_connected_devices
 from mbed_tools.cli.project_management import init, clone, checkout, libs
 
 

--- a/src/mbed_tools/cli/main.py
+++ b/src/mbed_tools/cli/main.py
@@ -4,6 +4,7 @@
 #
 """Main cli entry point."""
 import logging
+import sys
 
 from pkg_resources import get_distribution
 from typing import Union, Any
@@ -33,8 +34,10 @@ class GroupWithExceptionHandling(click.Group):
         """
         # Use the context manager to ensure tools exceptions (expected behaviour) are shown as messages to the user,
         # but all other exceptions (unexpected behaviour) are shown as errors.
-        with MbedToolsHandler(LOGGER, context.params["traceback"]):
+        with MbedToolsHandler(LOGGER, context.params["traceback"]) as handler:
             super().invoke(context)
+
+        sys.exit(handler.exit_code)
 
 
 def print_version(context: click.Context, param: Union[click.Option, click.Parameter], value: bool) -> Any:

--- a/src/mbed_tools/lib/logging.py
+++ b/src/mbed_tools/lib/logging.py
@@ -35,6 +35,7 @@ class MbedToolsHandler:
         """Keep track of the logger to use and whether or not a traceback should be generated."""
         self._logger = logger
         self._traceback = traceback
+        self.exit_code = 0
 
     def __enter__(self) -> "MbedToolsHandler":
         """Return the Context Manager."""
@@ -51,6 +52,7 @@ class MbedToolsHandler:
             error_msg = _exception_message(cast(BaseException, exc_value), logging.root.level, self._traceback)
             self._logger.error(error_msg, exc_info=self._traceback)
             # Do not propagate exceptions derived from ToolsError
+            self.exit_code = 1
             return True
 
         # Propagate all other exceptions

--- a/tests/cli/test_devices_command_integration.py
+++ b/tests/cli/test_devices_command_integration.py
@@ -26,8 +26,10 @@ class TestClickGroupWithExceptionHandling(TestCase):
         mock_cli = click.Command("test", callback=callback)
         cli.add_command(mock_cli, "test")
 
-        CliRunner().invoke(cli, ["test"])
+        runner = CliRunner()
+        result = runner.invoke(cli, ["test"])
 
+        self.assertEqual(1, result.exit_code)
         logger_error.assert_called_once()
 
 


### PR DESCRIPTION
### Description

<!--
Please add any detail or context that would be useful to a reviewer.
-->
When `ToolsError` exceptions were raised the tools returned an exit code of 0.

Return 1 when `ToolsError` is raised.

### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [x]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
