### PR TITLE
pre-commit-config: Remove assert news check

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,15 +1,5 @@
 - repo: local
   hooks:
-    - id: assertnews
-      name: news file
-      entry: assert-news -l
-      language: python
-      types: [file]
-      require_serial: true
-      verbose: true
-      always_run: true
-      pass_filenames: false
-
     - id: licensing
       name: licensing
       entry: license-files

--- a/azure-pipelines/build-release.yml
+++ b/azure-pipelines/build-release.yml
@@ -121,7 +121,7 @@ stages:
           - template: steps/install-development-dependencies.yml
 
           - script: |
-              assert-news -b $(current_branch)
+              assert-news -l
             displayName: 'Run check'
 
   - stage: DocBuild

--- a/news/20200730145703.misc
+++ b/news/20200730145703.misc
@@ -1,0 +1,1 @@
+Remove assert-news check

--- a/src/mbed_tools/project/mbed_program.py
+++ b/src/mbed_tools/project/mbed_program.py
@@ -147,7 +147,7 @@ class MbedProgram:
 
     def list_known_library_dependencies(self) -> List[MbedLibReference]:
         """Returns a list of all known library dependencies."""
-        return [lib for lib in self.lib_references.iter_all()]
+        return sorted([lib for lib in self.lib_references.iter_all()])
 
     def has_unresolved_libraries(self) -> bool:
         """Checks if any unresolved library dependencies exist in the program tree."""


### PR DESCRIPTION
### Description

<!--
Please add any detail or context that would be useful to a reviewer.
-->

Remove assert-news check from pre-commit hooks.
Fix assert-news CI for forked repos
Fix failing test

### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [x]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
