### PR TITLE
Make the configure command use the mbed program root directory as output

### DIFF
--- a/news/20200805143228.bugfix
+++ b/news/20200805143228.bugfix
@@ -1,0 +1,1 @@
+Remove output path and use program root for configure command output

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup(
     include_package_data=True,
     install_requires=[
         "python-dotenv",
-        "Click==7.0",
+        "Click==7.1",
         "pdoc3",
         "GitPython",
         "tqdm",

--- a/src/mbed_tools/build/_internal/cmake_file.py
+++ b/src/mbed_tools/build/_internal/cmake_file.py
@@ -8,29 +8,29 @@ import pathlib
 from typing import Iterable
 
 import jinja2
-from mbed_tools.targets import get_target_by_name, Target
+from mbed_tools.targets import Target
 
 from mbed_tools.build._internal.config.config import Config
-from mbed_tools.build._internal.config.assemble_build_config import assemble_config
 
 TEMPLATES_DIRECTORY = pathlib.Path("_internal", "templates")
 TEMPLATE_NAME = "mbed_config.tmpl"
 
 
-def generate_mbed_config_cmake_file(mbed_target: str, program_path: pathlib.Path, toolchain_name: str) -> str:
+def generate_mbed_config_cmake_file(
+    mbed_target_name: str, target_build_attributes: Target, config: Config, toolchain_name: str
+) -> str:
     """Generate the top-level CMakeLists.txt file containing the correct definitions for a build.
 
     Args:
         mbed_target: the target the application is being built for
+        target_build_attributes: Target config object.
         program_path: the path to the local Mbed program
         toolchain_name: the toolchain to be used to build the application
 
     Returns:
         A string of rendered contents for the file.
     """
-    target_build_attributes = get_target_by_name(mbed_target, program_path)
-    config = assemble_config(mbed_target, program_path)
-    return _render_mbed_config_cmake_template(target_build_attributes, config, toolchain_name, mbed_target,)
+    return _render_mbed_config_cmake_template(target_build_attributes, config, toolchain_name, mbed_target_name,)
 
 
 def _render_mbed_config_cmake_template(

--- a/src/mbed_tools/build/_internal/config/assemble_build_config.py
+++ b/src/mbed_tools/build/_internal/config/assemble_build_config.py
@@ -10,20 +10,16 @@ from mbed_tools.build._internal.config.config import Config
 from mbed_tools.build._internal.config.cumulative_data import CumulativeData
 from mbed_tools.build._internal.config.source import Source
 from mbed_tools.build._internal.find_files import LabelFilter, filter_files, find_files
-from mbed_tools.project import MbedProgram
 
 
-def assemble_config(mbed_target: str, mbed_program_directory: Path) -> Config:
+def assemble_config(target_source: Source, mbed_program_directory: Path, mbed_app_file: Optional[Path]) -> Config:
     """Assemble Config for given target and program directory.
 
     The structure and configuration of MbedOS requires us to do multiple passes over
     configuration files, as each pass might affect which configuration files should be included
     in the final configuration.
     """
-    target_source = Source.from_target(mbed_target, mbed_program_directory)
     mbed_lib_files = find_files("mbed_lib.json", mbed_program_directory)
-    mbed_program = MbedProgram.from_existing(mbed_program_directory)
-    mbed_app_file = mbed_program.files.app_config_file
     return _assemble_config_from_sources_and_lib_files(target_source, mbed_lib_files, mbed_app_file)
 
 

--- a/src/mbed_tools/build/_internal/config/source.py
+++ b/src/mbed_tools/build/_internal/config/source.py
@@ -10,7 +10,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Iterable, Any
 
-from mbed_tools.targets import get_target_by_board_type
+from mbed_tools.targets import Target
 
 logger = logging.getLogger(__name__)
 
@@ -77,9 +77,8 @@ class Source:
         return cls(human_name=f"File: {file_name}", config=config, overrides=namespaced_overrides, macros=macros)
 
     @classmethod
-    def from_target(cls, mbed_target: str, mbed_program_directory: Path) -> "Source":
+    def from_target(cls, target: Target) -> "Source":
         """Build Source from retrieved mbed_tools.targets.Target data."""
-        target = get_target_by_board_type(mbed_target, mbed_program_directory)
         namespace = "target"
         config = _namespace_data(target.config, namespace)
 
@@ -91,10 +90,7 @@ class Source:
         namespaced_overrides = _namespace_data(overrides, namespace)
 
         return cls(
-            human_name=f"mbed_target.Target for {mbed_target}",
-            config=config,
-            overrides=namespaced_overrides,
-            macros=[],
+            human_name=f"mbed_target.Target for {target}", config=config, overrides=namespaced_overrides, macros=[],
         )
 
 

--- a/src/mbed_tools/cli/configure.py
+++ b/src/mbed_tools/cli/configure.py
@@ -7,8 +7,6 @@ import pathlib
 
 import click
 
-from typing import Any
-
 from mbed_tools.project import MbedProgram
 from mbed_tools.targets import get_target_by_name
 from mbed_tools.build._internal.cmake_file import generate_mbed_config_cmake_file
@@ -19,16 +17,6 @@ from mbed_tools.build._internal.write_files import write_file
 
 @click.command(
     help="Generate an Mbed OS config CMake file and write it to a .mbedbuild folder in the program directory."
-)
-@click.option(
-    "-o",
-    "--output-directory",
-    type=click.Path(),
-    default=".",
-    help=(
-        "Destination for the generated .mbedbuild/mbed_config.cmake file containing configuration parameters to build "
-        "Mbed OS. The default is the current working directory."
-    ),
 )
 @click.option(
     "-t",
@@ -45,18 +33,17 @@ from mbed_tools.build._internal.write_files import write_file
     default=".",
     help="Path to local Mbed program. By default is the current working directory.",
 )
-def configure(output_directory: Any, toolchain: str, mbed_target: str, program_path: str) -> None:
-    """Exports a mbed_config.cmake file to a .mbedbuild directory in the output path.
+def configure(toolchain: str, mbed_target: str, program_path: str) -> None:
+    """Exports a mbed_config.cmake file to a .mbedbuild directory in the program root.
 
     The parameters set in the CMake file will be dependent on the combination of
     toolchain and Mbed target provided and these can then control which parts of
     Mbed OS are included in the build.
 
-    This command will create the .mbedbuild directory at the output path if it doesn't
+    This command will create the .mbedbuild directory at the program root if it doesn't
     exist.
 
     Args:
-        output_directory: the path where .mbedbuild/mbed_config.cmake will be written
         toolchain: the toolchain you are using (eg. GCC_ARM, ARM)
         mbed_target: the target you are building for (eg. K64F)
         program_path: the path to the local Mbed program
@@ -66,6 +53,6 @@ def configure(output_directory: Any, toolchain: str, mbed_target: str, program_p
     target_build_attributes = get_target_by_name(mbed_target, program.mbed_os.targets_json_file)
     config = assemble_config(Source.from_target(target_build_attributes), program.root, program.files.app_config_file)
     cmake_file_contents = generate_mbed_config_cmake_file(mbed_target, target_build_attributes, config, toolchain)
-    output_directory = pathlib.Path(output_directory, ".mbedbuild")
+    output_directory = program.root / ".mbedbuild"
     write_file(output_directory, "mbed_config.cmake", cmake_file_contents)
     click.echo(f"mbed_config.cmake has been generated and written to '{str(output_directory.resolve())}'")

--- a/src/mbed_tools/cli/configure.py
+++ b/src/mbed_tools/cli/configure.py
@@ -9,7 +9,11 @@ import click
 
 from typing import Any
 
+from mbed_tools.project import MbedProgram
+from mbed_tools.targets import get_target_by_name
 from mbed_tools.build._internal.cmake_file import generate_mbed_config_cmake_file
+from mbed_tools.build._internal.config.assemble_build_config import assemble_config
+from mbed_tools.build._internal.config.source import Source
 from mbed_tools.build._internal.write_files import write_file
 
 
@@ -57,7 +61,11 @@ def configure(output_directory: Any, toolchain: str, mbed_target: str, program_p
         mbed_target: the target you are building for (eg. K64F)
         program_path: the path to the local Mbed program
     """
-    cmake_file_contents = generate_mbed_config_cmake_file(mbed_target.upper(), pathlib.Path(program_path), toolchain)
+    program = MbedProgram.from_existing(pathlib.Path(program_path))
+    mbed_target = mbed_target.upper()
+    target_build_attributes = get_target_by_name(mbed_target, program.mbed_os.targets_json_file)
+    config = assemble_config(Source.from_target(target_build_attributes), program.root, program.files.app_config_file)
+    cmake_file_contents = generate_mbed_config_cmake_file(mbed_target, target_build_attributes, config, toolchain)
     output_directory = pathlib.Path(output_directory, ".mbedbuild")
     write_file(output_directory, "mbed_config.cmake", cmake_file_contents)
     click.echo(f"mbed_config.cmake has been generated and written to '{str(output_directory.resolve())}'")

--- a/src/mbed_tools/cli/configure.py
+++ b/src/mbed_tools/cli/configure.py
@@ -29,7 +29,7 @@ from mbed_tools.build._internal.write_files import write_file
 @click.option(
     "-t",
     "--toolchain",
-    type=click.Choice(["ARM", "GCC_ARM"]),
+    type=click.Choice(["ARM", "GCC_ARM"], case_sensitive=False),
     required=True,
     help="The toolchain you are using to build your app.",
 )

--- a/src/mbed_tools/project/mbed_program.py
+++ b/src/mbed_tools/project/mbed_program.py
@@ -42,8 +42,9 @@ class MbedProgram:
         """
         self.repo = repo
         self.files = program_files
+        self.root = self.files.mbed_file.parent
         self.mbed_os = mbed_os
-        self.lib_references = LibraryReferences(root=self.files.mbed_file.parent, ignore_paths=[self.mbed_os.root])
+        self.lib_references = LibraryReferences(root=self.root, ignore_paths=[self.mbed_os.root])
 
     @classmethod
     def from_url(cls, url: str, dst_path: Path, check_mbed_os: bool = True) -> "MbedProgram":

--- a/src/mbed_tools/targets/get_target.py
+++ b/src/mbed_tools/targets/get_target.py
@@ -10,10 +10,9 @@ can be retrieved by calling one of the public functions.
 import pathlib
 
 from mbed_tools.targets.target import Target
-from mbed_tools.project import MbedProgram
 
 
-def get_target_by_name(name: str, path_to_mbed_program: pathlib.Path) -> Target:
+def get_target_by_name(name: str, path_to_targets_json: pathlib.Path) -> Target:
     """Returns the Target whose name matches the name given.
 
     The Target is as defined in the targets.json file found in the Mbed OS library.
@@ -22,17 +21,15 @@ def get_target_by_name(name: str, path_to_mbed_program: pathlib.Path) -> Target:
 
     Args:
         name: the name of the Target to be returned
-        path_to_mbed_program: path to an Mbed OS program
+        path_to_targets_json: path to a targets.json file containing target definitions
 
     Raises:
         TargetError: an error has occurred while fetching target
     """
-    mbed_program = MbedProgram.from_existing(pathlib.Path(path_to_mbed_program))
-    path_to_targets_json = mbed_program.mbed_os.targets_json_file
     return Target.from_targets_json(name, path_to_targets_json)
 
 
-def get_target_by_board_type(board_type: str, path_to_mbed_program: pathlib.Path) -> Target:
+def get_target_by_board_type(board_type: str, path_to_targets_json: pathlib.Path) -> Target:
     """Returns the Target whose name matches a board's build_type.
 
     The Target is as defined in the targets.json file found in the Mbed OS library.
@@ -41,9 +38,9 @@ def get_target_by_board_type(board_type: str, path_to_mbed_program: pathlib.Path
 
     Args:
         board_type: a board's board_type (see `mbed_tools.targets.board.Board`)
-        path_to_mbed_program: path to an Mbed OS program
+        path_to_targets_json: path to a targets.json file containing target definitions
 
     Raises:
         TargetError: an error has occurred while fetching target
     """
-    return get_target_by_name(board_type, path_to_mbed_program)
+    return get_target_by_name(board_type, path_to_targets_json)

--- a/tests/build/_internal/config/test_assemble_build_config.py
+++ b/tests/build/_internal/config/test_assemble_build_config.py
@@ -27,7 +27,6 @@ def create_files(directory, files):
     return created_files
 
 
-@mock.patch("mbed_tools.build._internal.config.assemble_build_config.MbedProgram", autospec=True)
 @mock.patch("mbed_tools.build._internal.config.assemble_build_config.Source", autospec=True)
 @mock.patch("mbed_tools.build._internal.config.assemble_build_config.find_files", autospec=True)
 @mock.patch(
@@ -35,18 +34,17 @@ def create_files(directory, files):
 )
 class TestAssembleConfig(TestCase):
     def test_calls_collaborator_with_source_and_file_paths(
-        self, _assemble_config_from_sources_and_lib_files, find_files, Source, MbedProgram,
+        self, _assemble_config_from_sources_and_lib_files, find_files, Source,
     ):
-        mbed_target = "K64F"
+        mbed_target = mock.Mock()
         mbed_program_directory = Path("foo")
-        program = mock.Mock()
-        MbedProgram.from_existing.return_value = program
+        app_config_file = mbed_program_directory / "mbed_app.json"
 
-        subject = assemble_config(mbed_target, mbed_program_directory)
+        subject = assemble_config(Source.from_target(mbed_target), mbed_program_directory, app_config_file)
 
         self.assertEqual(subject, _assemble_config_from_sources_and_lib_files.return_value)
         _assemble_config_from_sources_and_lib_files.assert_called_once_with(
-            Source.from_target.return_value, find_files.return_value, program.files.app_config_file
+            Source.from_target.return_value, find_files.return_value, app_config_file
         )
         find_files.assert_called_once_with("mbed_lib.json", mbed_program_directory)
 

--- a/tests/build/_internal/config/test_source.py
+++ b/tests/build/_internal/config/test_source.py
@@ -79,8 +79,7 @@ class TestSource(TestCase):
             ),
         )
 
-    @mock.patch("mbed_tools.build._internal.config.source.get_target_by_board_type")
-    def test_from_target(self, get_target_by_board_type):
+    def test_from_target(self):
         # Warning: Target is a dataclass and dataclasses provide no type safety when mocking
         target = mock.Mock(
             features={"feature_1"},
@@ -88,16 +87,13 @@ class TestSource(TestCase):
             labels={"label_1"},
             config={"foo": "bar", "target.bool": True},
         )
-        get_target_by_board_type.return_value = target
-        mbed_target = "K66F"
-        mbed_program_directory = pathlib.Path("foo")
 
-        subject = Source.from_target(mbed_target, mbed_program_directory)
+        subject = Source.from_target(target)
 
         self.assertEqual(
             subject,
             Source(
-                human_name=f"mbed_target.Target for {mbed_target}",
+                human_name=f"mbed_target.Target for {target}",
                 config={"target.foo": "bar", "target.bool": True},
                 overrides={
                     "target.features": target.features,

--- a/tests/build/_internal/test_cmake_file.py
+++ b/tests/build/_internal/test_cmake_file.py
@@ -2,8 +2,6 @@
 # Copyright (C) 2020 Arm Mbed. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
-import pathlib
-
 from unittest import TestCase, mock
 
 from tests.build._internal.config.factories import ConfigFactory
@@ -12,9 +10,7 @@ from mbed_tools.build._internal.cmake_file import generate_mbed_config_cmake_fil
 
 class TestGenerateCMakeListsFile(TestCase):
     @mock.patch("mbed_tools.build._internal.cmake_file.datetime")
-    @mock.patch("mbed_tools.build._internal.cmake_file.assemble_config")
-    @mock.patch("mbed_tools.build._internal.cmake_file.get_target_by_name")
-    def test_correct_arguments_passed(self, get_target_by_name, assemble_config, datetime):
+    def test_correct_arguments_passed(self, datetime):
         target = mock.Mock()
         target.labels = ["foo"]
         target.features = ["bar"]
@@ -26,16 +22,11 @@ class TestGenerateCMakeListsFile(TestCase):
         datetime = mock.Mock()
         datetime.datetime.now.return_value.timestamp.return_value = 2
         config = ConfigFactory()
-        assemble_config.return_value = config
-        get_target_by_name.return_value = target
         mbed_target = "K64F"
-        program_path = pathlib.Path("blinky")
         toolchain_name = "GCC"
 
-        result = generate_mbed_config_cmake_file(mbed_target, program_path, toolchain_name)
+        result = generate_mbed_config_cmake_file(mbed_target, target, config, toolchain_name)
 
-        get_target_by_name.assert_called_once_with(mbed_target, program_path)
-        assemble_config.assert_called_once_with(mbed_target, program_path)
         self.assertEqual(
             result, _render_mbed_config_cmake_template(target, config, toolchain_name, mbed_target,),
         )

--- a/tests/build/_internal/test_find_files.py
+++ b/tests/build/_internal/test_find_files.py
@@ -9,7 +9,7 @@ from unittest import TestCase
 from typing import Iterable
 
 
-from mbed_tools.build._internal.find_files import find_files, filter_files, MbedignoreFilter, LabelFilter
+from mbed_tools.build._internal.find_files import find_files, filter_files, MbedignoreFilter, LabelFilter, _find_files
 
 
 @contextlib.contextmanager
@@ -70,6 +70,18 @@ class TestFindFiles(TestCase):
         ]
         with create_files(matching_paths + excluded_paths) as directory:
             subject = find_files("file.txt", directory)
+
+        self.assertEqual(len(subject), len(matching_paths))
+        for path in matching_paths:
+            self.assertIn(Path(directory, path), subject)
+
+    def test_finds_all_with_no_filters(self):
+        matching_paths = [
+            Path("file.txt"),
+            Path("bar", "file.txt"),
+        ]
+        with create_files(matching_paths) as directory:
+            subject = _find_files("file.txt", directory)
 
         self.assertEqual(len(subject), len(matching_paths))
         for path in matching_paths:

--- a/tests/cli/test_configure.py
+++ b/tests/cli/test_configure.py
@@ -1,0 +1,42 @@
+#
+# Copyright (C) 2020 Arm Mbed. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+import pathlib
+
+from unittest import TestCase, mock
+
+from click.testing import CliRunner
+
+from mbed_tools.cli.configure import configure
+
+
+class TestConfigureCommand(TestCase):
+    @mock.patch("mbed_tools.cli.configure.MbedProgram")
+    @mock.patch("mbed_tools.cli.configure.get_target_by_name")
+    @mock.patch("mbed_tools.cli.configure.generate_mbed_config_cmake_file")
+    @mock.patch("mbed_tools.cli.configure.assemble_config")
+    @mock.patch("mbed_tools.cli.configure.Source")
+    @mock.patch("mbed_tools.cli.configure.write_file")
+    def test_collaborators_called_with_corrrect_arguments(
+        self, write_file, source, assemble_config, gen_config_cmake, get_target_by_name, mbed_program
+    ):
+        CliRunner().invoke(configure, ["-m", "k64f", "-t", "GCC_ARM"])
+
+        mbed_program.from_existing.assert_called_once_with(pathlib.Path("."))
+        get_target_by_name.assert_called_once_with(
+            "K64F", mbed_program.from_existing.return_value.mbed_os.targets_json_file
+        )
+        assemble_config.assert_called_once_with(
+            source.from_target.return_value,
+            mbed_program.from_existing.return_value.root,
+            mbed_program.from_existing.return_value.files.app_config_file,
+        )
+        gen_config_cmake.assert_called_once_with(
+            "K64F", get_target_by_name.return_value, assemble_config.return_value, "GCC_ARM"
+        )
+        write_file.assert_called_once_with(
+            mbed_program.from_existing.return_value.root / ".mbedbuild",
+            "mbed_config.cmake",
+            gen_config_cmake.return_value,
+        )

--- a/tests/targets/test_get_target.py
+++ b/tests/targets/test_get_target.py
@@ -2,27 +2,23 @@
 # Copyright (C) 2020 Arm Mbed. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
-import pathlib
 from unittest import TestCase, mock
 from mbed_tools.targets.target import Target
 from mbed_tools.targets.get_target import get_target_by_board_type, get_target_by_name
-from mbed_tools.project import MbedProgram
 
 
 class TestGetTarget(TestCase):
     @mock.patch("mbed_tools.targets.get_target.Target", spec_set=Target)
-    @mock.patch("mbed_tools.targets.get_target.MbedProgram", spec_set=MbedProgram)
-    def test_get_by_name(self, MbedProgram, MockTarget):
+    def test_get_by_name(self, MockTarget):
         target_name = "Target"
-        path_to_mbed_program = "my-program"
+        targets_json_file_path = "targets.json"
 
-        result = get_target_by_name(target_name, path_to_mbed_program)
+        result = get_target_by_name(target_name, targets_json_file_path)
 
         self.assertEqual(result, MockTarget.from_targets_json.return_value)
         MockTarget.from_targets_json.assert_called_once_with(
-            target_name, MbedProgram.from_existing.return_value.mbed_os.targets_json_file,
+            target_name, targets_json_file_path,
         )
-        MbedProgram.from_existing.assert_called_once_with(pathlib.Path(path_to_mbed_program))
 
     @mock.patch("mbed_tools.targets.get_target.get_target_by_name")
     def test_get_by_board_type(self, mock_get_target_by_name):


### PR DESCRIPTION
### Description

<!--
Please add any detail or context that would be useful to a reviewer.
-->

The configure command wasn't using the MbedProgram object to find the root directory of the project. Meaning if the user was in a program subdirectory and didn't specify an output path, the config file would be created in the wrong place and the build would fail.

While I'm here, I've tried to remove unnecessary instantiations of the `MbedProgram` and `Target` objects and decouple them from the `build` module. Previously we were creating multiple `MbedProgram` and `Target` objects in different functions. I've pulled the creation of these objects up to the top level command handler. This code could still be improved further but I think this is enough of an improvement for this PR.


### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [x]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
