### PR TITLE
pre-commit: Don't run pytest unless python files change

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,7 +29,6 @@
       entry: mypy src/mbed_tools
       language: python
       types: [python]
-      require_serial: true
       pass_filenames: false
 
     - id: pytest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,5 +37,4 @@
       language: python
       types: [python]
       pass_filenames: false
-      always_run: true
 

--- a/news/20200805160557.misc
+++ b/news/20200805160557.misc
@@ -1,0 +1,1 @@
+Improve pre-commit config by only running pytest when python files change


### PR DESCRIPTION
### Description

<!--
Please add any detail or context that would be useful to a reviewer.
-->
We don't need to run pytest unless python files change.

mypy doesn't need to be forced to run serially.

### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [ ]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [x]  Additional tests are not required for this change (e.g. documentation update).
