### PR TITLE
project: Remove dependency on .mbed file

### DIFF
--- a/news/20200805210417.bugfix
+++ b/news/20200805210417.bugfix
@@ -1,0 +1,1 @@
+Remove mbed-tools/project's dependency on the legacy .mbed file

--- a/src/mbed_tools/project/_internal/project_data.py
+++ b/src/mbed_tools/project/_internal/project_data.py
@@ -17,7 +17,6 @@ TARGETS_JSON_FILE_PATH = Path("targets", "targets.json")
 MBED_OS_DIR_NAME = "mbed-os"
 MBED_OS_REFERENCE_URL = "https://github.com/ARMmbed/mbed-os"
 MBED_OS_REFERENCE_FILE_NAME = "mbed-os.lib"
-PROGRAM_ROOT_FILE_NAME = ".mbed"
 APP_CONFIG_FILE_NAME = "mbed_app.json"
 
 
@@ -32,18 +31,15 @@ class MbedProgramFiles:
 
     This object holds paths to the various files which define an MbedProgram.
 
-    All MbedPrograms must contain a .mbed file, which defines the program root path. MbedPrograms must also contain an
-    mbed-os.lib reference file, defining Mbed OS as a program dependency. Because the mbed-os.lib reference is required
-    by all Mbed programs the path to the file is stored in this object.
+    MbedPrograms must contain an mbed-os.lib reference file, defining Mbed OS as a program dependency. A program can
+    optionally include an mbed_app.json file which defines application level config.
 
     Attributes:
         app_config_file: Path to mbed_app.json file. This can be `None` if the program doesn't set any custom config.
-        mbed_file: Path to the .mbed file which defines the program root.
         mbed_os_ref: Library reference file for MbedOS. All programs require this file.
     """
 
     app_config_file: Optional[Path]
-    mbed_file: Path
     mbed_os_ref: Path
 
     @classmethod
@@ -59,16 +55,14 @@ class MbedProgramFiles:
             ValueError: A program .mbed or mbed-os.lib file already exists at this path.
         """
         app_config = root_path / APP_CONFIG_FILE_NAME
-        mbed_file = root_path / PROGRAM_ROOT_FILE_NAME
         mbed_os_ref = root_path / MBED_OS_REFERENCE_FILE_NAME
 
-        if mbed_file.exists() or mbed_os_ref.exists():
+        if mbed_os_ref.exists():
             raise ValueError(f"Program already exists at path {root_path}.")
 
-        mbed_file.touch()
         app_config.write_text(json.dumps(DEFAULT_APP_CONFIG, indent=4))
         mbed_os_ref.write_text(f"{MBED_OS_REFERENCE_URL}#master")
-        return cls(app_config_file=app_config, mbed_file=mbed_file, mbed_os_ref=mbed_os_ref)
+        return cls(app_config_file=app_config, mbed_os_ref=mbed_os_ref)
 
     @classmethod
     def from_existing(cls, root_path: Path) -> "MbedProgramFiles":
@@ -87,13 +81,8 @@ class MbedProgramFiles:
             app_config = None
 
         mbed_os_file = root_path / MBED_OS_REFERENCE_FILE_NAME
-        if not mbed_os_file.exists():
-            raise ValueError("This path does not contain an mbed-os.lib, which is required for mbed programs.")
 
-        mbed_file = root_path / PROGRAM_ROOT_FILE_NAME
-        mbed_file.touch(exist_ok=True)
-
-        return cls(app_config_file=app_config, mbed_file=mbed_file, mbed_os_ref=mbed_os_file)
+        return cls(app_config_file=app_config, mbed_os_ref=mbed_os_file)
 
 
 @dataclass

--- a/tests/project/_internal/test_mbed_program.py
+++ b/tests/project/_internal/test_mbed_program.py
@@ -18,7 +18,7 @@ class TestInitialiseProgram(TestCase):
     def test_from_new_local_dir_raises_if_path_is_existing_program(self, fs):
         program_root = pathlib.Path(fs, "programfoo")
         program_root.mkdir()
-        (program_root / ".mbed").touch()
+        (program_root / "mbed-os.lib").touch()
 
         with self.assertRaises(ExistingProgram):
             MbedProgram.from_new(program_root)
@@ -87,16 +87,6 @@ class TestInitialiseProgram(TestCase):
             MbedProgram.from_existing(program_root)
 
     @patchfs
-    def test_from_existing_raises_if_program_files_missing(self, fs):
-        fs_root = pathlib.Path(fs, "foo")
-        fs_root.mkdir()
-        (fs_root / ".mbed").touch()
-        program_root = fs_root
-
-        with self.assertRaises(ProgramNotFound):
-            MbedProgram.from_existing(program_root)
-
-    @patchfs
     def test_from_existing_raises_if_no_repo_found(self, fs):
         fs_root = pathlib.Path(fs, "foo")
         make_mbed_program_files(fs_root)
@@ -130,14 +120,14 @@ class TestInitialiseProgram(TestCase):
 class TestLibReferenceHandling(TestCase):
     @mock.patch("mbed_tools.project.mbed_program.LibraryReferences", autospec=True)
     def test_resolve_libraries(self, mock_lib_refs):
-        program = MbedProgram(None, MbedProgramFiles(None, pathlib.Path(), None), MbedOS(pathlib.Path(), None))
+        program = MbedProgram(None, MbedProgramFiles(None, pathlib.Path()), MbedOS(pathlib.Path(), None))
         program.resolve_libraries()
 
         program.lib_references.resolve.assert_called_once()
 
     @mock.patch("mbed_tools.project.mbed_program.LibraryReferences", autospec=True)
     def test_checkout_libraries(self, mock_lib_refs):
-        program = MbedProgram(None, MbedProgramFiles(None, pathlib.Path(), None), MbedOS(pathlib.Path(), None))
+        program = MbedProgram(None, MbedProgramFiles(None, pathlib.Path()), MbedOS(pathlib.Path(), None))
         program.checkout_libraries()
 
         program.lib_references.checkout.assert_called_once()
@@ -153,7 +143,7 @@ class TestLibReferenceHandling(TestCase):
         mbed_os_root.mkdir()
 
         program = MbedProgram(
-            None, MbedProgramFiles(None, pathlib.Path(root, ".mbed"), None), MbedOS(mbed_os_root, None)
+            None, MbedProgramFiles(None, pathlib.Path(root, "mbed-os.lib")), MbedOS(mbed_os_root, None)
         )
         libs = program.list_known_library_dependencies()
         self.assertEqual(str(lib_ref_unresolved), str(libs[0]))
@@ -168,7 +158,7 @@ class TestLibReferenceHandling(TestCase):
         mbed_os_root.mkdir()
 
         program = MbedProgram(
-            None, MbedProgramFiles(None, pathlib.Path(root / ".mbed"), None), MbedOS(mbed_os_root, None)
+            None, MbedProgramFiles(None, pathlib.Path(root / "mbed-os.lib")), MbedOS(mbed_os_root, None)
         )
         self.assertTrue(program.has_unresolved_libraries())
 

--- a/tests/project/_internal/test_project_data.py
+++ b/tests/project/_internal/test_project_data.py
@@ -30,14 +30,6 @@ class TestMbedProgramFiles(TestCase):
         self.assertTrue(program.app_config_file.exists())
 
     @patchfs
-    def test_from_existing_raises_if_program_doesnt_exist(self, fs):
-        root = pathlib.Path(fs, "foo")
-        root.mkdir()
-
-        with self.assertRaises(ValueError):
-            MbedProgramFiles.from_existing(root)
-
-    @patchfs
     def test_from_existing_finds_existing_program_data(self, fs):
         root = pathlib.Path(fs, "foo")
         make_mbed_program_files(root)

--- a/tests/project/factories.py
+++ b/tests/project/factories.py
@@ -20,7 +20,6 @@ def make_mbed_program_files(root, config_file_name="mbed_app.json"):
     if not root.exists():
         root.mkdir()
 
-    (root / ".mbed").touch()
     (root / "mbed-os.lib").touch()
     (root / config_file_name).touch()
 


### PR DESCRIPTION
### Description

<!--
Please add any detail or context that would be useful to a reviewer.
-->
If a user manually git clones an Mbed project, and it doesn't contain a
.mbed file, they would have to create it manually. This is not good UX.
Instead check for the presence of an mbed-os.lib file, as this file is
required in all Mbed programs.


### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [x]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
