### PR TITLE
Generate project startup files from "init" command

### DIFF
--- a/news/20200810123455.feature
+++ b/news/20200810123455.feature
@@ -1,0 +1,1 @@
+Generate project startup files from init command

--- a/src/mbed_tools/project/_internal/git_utils.py
+++ b/src/mbed_tools/project/_internal/git_utils.py
@@ -51,12 +51,10 @@ def checkout(repo: git.Repo, ref: str, force: bool = False) -> None:
     Raises:
         VersionControlError: Check out failed.
     """
-    git_object = git.repo.fun.name_to_object(repo, ref)
-    commit = git.repo.fun.to_commit(git_object)
     try:
-        repo.git.checkout(f"--force {commit}" if force else str(commit))
+        repo.git.checkout(f"--force {ref}" if force else str(ref))
     except git.exc.GitCommandError as err:
-        raise VersionControlError(f"Failed to check out revision '{commit}'. Error from VCS: {err.stderr}")
+        raise VersionControlError(f"Failed to check out revision '{ref}'. Error from VCS: {err.stderr}")
 
 
 def init(path: Path) -> git.Repo:

--- a/src/mbed_tools/project/_internal/render_templates.py
+++ b/src/mbed_tools/project/_internal/render_templates.py
@@ -1,0 +1,56 @@
+#
+# Copyright (C) 2020 Arm Mbed. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+"""Render jinja templates required by the project package."""
+import datetime
+
+from pathlib import Path
+
+import jinja2
+
+TEMPLATES_DIRECTORY = Path("_internal", "templates")
+
+
+def render_cmakelists_template(cmakelists_file: Path, program_name: str) -> None:
+    """Render CMakeLists.tmpl with the copyright year and program name as the app target name.
+
+    Args:
+        cmakelists_file: The path where CMakeLists.txt will be written.
+        program_name: The name of the program, will be used as the app target name.
+    """
+    cmakelists_file.write_text(
+        render_jinja_template(
+            "CMakeLists.tmpl", {"program_name": program_name, "year": str(datetime.datetime.now().year)}
+        )
+    )
+
+
+def render_main_cpp_template(main_cpp: Path) -> None:
+    """Render a basic main.cpp which prints a hello message and returns.
+
+    Args:
+        main_cpp: Path where the main.cpp file will be written.
+    """
+    main_cpp.write_text(render_jinja_template("main.tmpl", {"year": str(datetime.datetime.now().year)}))
+
+
+def render_gitignore_template(gitignore: Path) -> None:
+    """Write out a basic gitignore file ignoring the build and config directory.
+
+    Args:
+        gitignore: The path where the gitignore file will be written.
+    """
+    gitignore.write_text(render_jinja_template("gitignore.tmpl", {}))
+
+
+def render_jinja_template(template_name: str, context: dict) -> str:
+    """Render a jinja template.
+
+    Args:
+        template_name: The name of the template being rendered.
+        context: Data to render into the jinja template.
+    """
+    env = jinja2.Environment(loader=jinja2.PackageLoader("mbed_tools.project", str(TEMPLATES_DIRECTORY)))
+    template = env.get_template(template_name)
+    return template.render(context)

--- a/src/mbed_tools/project/_internal/templates/CMakeLists.tmpl
+++ b/src/mbed_tools/project/_internal/templates/CMakeLists.tmpl
@@ -1,0 +1,27 @@
+# Copyright (c) {{year}} ARM Limited. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.18.1)
+
+set(MBED_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/mbed-os CACHE INTERNAL "")
+set(MBED_CONFIG_PATH ${CMAKE_CURRENT_SOURCE_DIR}/.mbedbuild CACHE INTERNAL "")
+set(APP_TARGET {{program_name}})
+
+add_subdirectory(${MBED_ROOT})
+
+add_executable(${APP_TARGET}
+    main.cpp
+)
+
+mbed_os_target_linker_script(${APP_TARGET})
+
+project(${APP_TARGET})
+
+target_link_libraries(${APP_TARGET} mbed-os)
+
+mbed_os_bin_hex(${APP_TARGET})
+
+option(VERBOSE_BUILD "Have a verbose build process")
+if(VERBOSE_BUILD)
+    set(CMAKE_VERBOSE_MAKEFILE ON)
+endif()

--- a/src/mbed_tools/project/_internal/templates/__init__.py
+++ b/src/mbed_tools/project/_internal/templates/__init__.py
@@ -1,0 +1,5 @@
+#
+# Copyright (C) 2020 Arm Mbed. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+"""Package containing jinja templates used by mbed_tools.project."""

--- a/src/mbed_tools/project/_internal/templates/gitignore.tmpl
+++ b/src/mbed_tools/project/_internal/templates/gitignore.tmpl
@@ -1,0 +1,2 @@
+.mbedbuild
+cmake_build/

--- a/src/mbed_tools/project/_internal/templates/main.tmpl
+++ b/src/mbed_tools/project/_internal/templates/main.tmpl
@@ -1,0 +1,13 @@
+/* mbed Microcontroller Library
+ * Copyright (c) {{year}} ARM Limited
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "mbed.h"
+
+
+int main()
+{
+    printf("Hello, Mbed!\n");
+    return 0;
+}

--- a/tests/project/_internal/test_git_utils.py
+++ b/tests/project/_internal/test_git_utils.py
@@ -52,3 +52,17 @@ class TestGetRepo(TestCase):
 
         with self.assertRaises(VersionControlError):
             git_utils.get_repo(Path())
+
+
+@mock.patch("mbed_tools.project._internal.git_utils.git.Repo", autospec=True)
+class TestCheckout(TestCase):
+    def test_git_lib_called_with_correct_command(self, mock_repo):
+        git_utils.checkout(mock_repo, "master", force=True)
+
+        mock_repo.git.checkout.assert_called_once_with("--force master")
+
+    def test_raises_version_control_error_when_git_checkout_fails(self, mock_repo):
+        mock_repo.git.checkout.side_effect = git_utils.git.exc.GitCommandError("git checkout", 255)
+
+        with self.assertRaises(VersionControlError):
+            git_utils.checkout(mock_repo, "bad")

--- a/tests/project/_internal/test_mbed_program.py
+++ b/tests/project/_internal/test_mbed_program.py
@@ -119,15 +119,15 @@ class TestInitialiseProgram(TestCase):
 
 class TestLibReferenceHandling(TestCase):
     @mock.patch("mbed_tools.project.mbed_program.LibraryReferences", autospec=True)
-    def test_resolve_libraries(self, mock_lib_refs):
-        program = MbedProgram(None, MbedProgramFiles(None, pathlib.Path()), MbedOS(pathlib.Path(), None))
+    def test_resolve_libraries_delegation(self, mock_lib_refs):
+        program = MbedProgram(MbedProgramFiles(None, pathlib.Path(), pathlib.Path()), MbedOS(pathlib.Path(), None))
         program.resolve_libraries()
 
         program.lib_references.resolve.assert_called_once()
 
     @mock.patch("mbed_tools.project.mbed_program.LibraryReferences", autospec=True)
-    def test_checkout_libraries(self, mock_lib_refs):
-        program = MbedProgram(None, MbedProgramFiles(None, pathlib.Path()), MbedOS(pathlib.Path(), None))
+    def test_checkout_libraries_delegation(self, mock_lib_refs):
+        program = MbedProgram(MbedProgramFiles(None, pathlib.Path(), pathlib.Path()), MbedOS(pathlib.Path(), None))
         program.checkout_libraries()
 
         program.lib_references.checkout.assert_called_once()
@@ -143,7 +143,7 @@ class TestLibReferenceHandling(TestCase):
         mbed_os_root.mkdir()
 
         program = MbedProgram(
-            None, MbedProgramFiles(None, pathlib.Path(root, "mbed-os.lib")), MbedOS(mbed_os_root, None)
+            MbedProgramFiles(None, pathlib.Path(root, "mbed-os.lib"), pathlib.Path()), MbedOS(mbed_os_root, None),
         )
         libs = program.list_known_library_dependencies()
         self.assertEqual(str(lib_ref_unresolved), str(libs[0]))
@@ -158,7 +158,7 @@ class TestLibReferenceHandling(TestCase):
         mbed_os_root.mkdir()
 
         program = MbedProgram(
-            None, MbedProgramFiles(None, pathlib.Path(root / "mbed-os.lib")), MbedOS(mbed_os_root, None)
+            MbedProgramFiles(None, pathlib.Path(root / "mbed-os.lib"), pathlib.Path()), MbedOS(mbed_os_root, None),
         )
         self.assertTrue(program.has_unresolved_libraries())
 

--- a/tests/project/_internal/test_mbed_program.py
+++ b/tests/project/_internal/test_mbed_program.py
@@ -7,7 +7,7 @@ import pathlib
 from unittest import mock, TestCase
 
 from mbed_tools.project import MbedProgram
-from mbed_tools.project.exceptions import ExistingProgram, ProgramNotFound, MbedOSNotFound, VersionControlError
+from mbed_tools.project.exceptions import ExistingProgram, ProgramNotFound, MbedOSNotFound
 from mbed_tools.project.mbed_program import _find_program_root, parse_url
 from mbed_tools.project._internal.project_data import MbedProgramFiles, MbedOS
 from tests.project.factories import make_mbed_program_files, make_mbed_os_files, make_mbed_lib_reference, patchfs
@@ -24,8 +24,7 @@ class TestInitialiseProgram(TestCase):
             MbedProgram.from_new(program_root)
 
     @patchfs
-    @mock.patch("mbed_tools.project._internal.git_utils.init", autospec=True)
-    def test_from_new_local_dir_generates_valid_program(self, mock_init, fs):
+    def test_from_new_local_dir_generates_valid_program(self, fs):
         fs_root = pathlib.Path(fs, "foo")
         fs_root.mkdir()
         program_root = fs_root / "programfoo"
@@ -33,8 +32,6 @@ class TestInitialiseProgram(TestCase):
         program = MbedProgram.from_new(program_root)
 
         self.assertEqual(program.files, MbedProgramFiles.from_existing(program_root))
-        self.assertEqual(program.repo, mock_init.return_value)
-        mock_init.assert_called_once_with(program_root)
 
     @patchfs
     def test_from_url_raises_if_dest_dir_contains_program(self, fs):
@@ -87,16 +84,7 @@ class TestInitialiseProgram(TestCase):
             MbedProgram.from_existing(program_root)
 
     @patchfs
-    def test_from_existing_raises_if_no_repo_found(self, fs):
-        fs_root = pathlib.Path(fs, "foo")
-        make_mbed_program_files(fs_root)
-
-        with self.assertRaises(VersionControlError):
-            MbedProgram.from_existing(fs_root)
-
-    @patchfs
-    @mock.patch("mbed_tools.project._internal.git_utils.git.Repo", autospec=True)
-    def test_from_existing_raises_if_no_mbed_os_dir_found_and_check_mbed_os_is_true(self, mock_repo, fs):
+    def test_from_existing_raises_if_no_mbed_os_dir_found_and_check_mbed_os_is_true(self, fs):
         fs_root = pathlib.Path(fs, "foo")
         make_mbed_program_files(fs_root)
 
@@ -104,8 +92,7 @@ class TestInitialiseProgram(TestCase):
             MbedProgram.from_existing(fs_root, check_mbed_os=True)
 
     @patchfs
-    @mock.patch("mbed_tools.project._internal.git_utils.git.Repo", autospec=True)
-    def test_from_existing_returns_valid_program(self, mock_repo, fs):
+    def test_from_existing_returns_valid_program(self, fs):
         fs_root = pathlib.Path(fs, "foo")
         make_mbed_program_files(fs_root)
         make_mbed_os_files(fs_root / "mbed-os")
@@ -114,7 +101,6 @@ class TestInitialiseProgram(TestCase):
 
         self.assertTrue(program.files.app_config_file.exists())
         self.assertTrue(program.mbed_os.root.exists())
-        self.assertIsNotNone(program.repo)
 
 
 class TestLibReferenceHandling(TestCase):

--- a/tests/project/_internal/test_render_templates.py
+++ b/tests/project/_internal/test_render_templates.py
@@ -1,0 +1,48 @@
+#
+# Copyright (C) 2020 Arm Mbed. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest import TestCase, mock
+
+from mbed_tools.project._internal.render_templates import (
+    render_cmakelists_template,
+    render_main_cpp_template,
+    render_gitignore_template,
+)
+
+
+@mock.patch("mbed_tools.project._internal.render_templates.datetime")
+class TestRenderTemplates(TestCase):
+    def test_renders_cmakelists_template(self, mock_datetime):
+        with TemporaryDirectory() as tmpdir:
+            the_year = 3999
+            mock_datetime.datetime.now.return_value.year = the_year
+            program_name = "mytestprogram"
+            file_path = Path(tmpdir, "mytestpath")
+
+            render_cmakelists_template(file_path, program_name)
+
+            output = file_path.read_text()
+            self.assertIn(str(the_year), output)
+            self.assertIn(program_name, output)
+
+    def test_renders_main_cpp_template(self, mock_datetime):
+        with TemporaryDirectory() as tmpdir:
+            the_year = 3999
+            mock_datetime.datetime.now.return_value.year = the_year
+            file_path = Path(tmpdir, "mytestpath")
+
+            render_main_cpp_template(file_path)
+
+            self.assertIn(str(the_year), file_path.read_text())
+
+    def test_renders_gitignore_template(self, _):
+        with TemporaryDirectory() as tmpdir:
+            file_path = Path(tmpdir, "mytestpath")
+
+            render_gitignore_template(file_path)
+
+            self.assertIn("cmake_build", file_path.read_text())
+            self.assertIn(".mbedbuild", file_path.read_text())


### PR DESCRIPTION
### Description

<!--
Please add any detail or context that would be useful to a reviewer.
-->

Generate a CMakeLists.txt, main.cpp and .gitignore from the "init" command

Depends on: https://github.com/ARMmbed/mbed-tools/pull/45

### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [x]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
