### PR TITLE
config: fix build type

### DIFF
--- a/news/20200813.bugfix
+++ b/news/20200813.bugfix
@@ -1,0 +1,1 @@
+Removing unused MBED_PROFILE, please use CMAKE_BUILD_TYPE to select a profile.

--- a/src/mbed_tools/build/_internal/templates/mbed_config.tmpl
+++ b/src/mbed_tools/build/_internal/templates/mbed_config.tmpl
@@ -7,7 +7,6 @@
 set(MBED_TOOLCHAIN "{{toolchain_name}}" CACHE STRING "")
 set(MBED_TARGET "{{target_name}}" CACHE STRING "")
 set(MBED_CPU_CORE "{{core}}" CACHE STRING "")
-set(MBED_PROFILE "develop" CACHE STRING "")
 
 list(APPEND MBED_TARGET_LABELS{% for label in labels %}
     {{label}}


### PR DESCRIPTION
### Description

<!--
Please add any detail or context that would be useful to a reviewer.
-->

Use `CMAKE_BUILD_TYPE ` instead of `MBED_PROFILE`. I've noticed develop is hardcoded. Do tools already provide profile argument? I don't see it in `mbedtools configure --help`. 

My questions: should we just remove `CMAKE_BUILD_TYPE` from the template, and let a user to provide -DCMAKE_BUILD_TYPE to CMake? `mbed compile` provides `--profile` so this would be a user flow change. All profiles are known in the CMake anyway so mbedtools do not know anything about it anymore (compare to the told tools), correct?

Not yet tested, waiting for your feedback how to pass the profile to CMake and I'll test it locally.

cc @hugueskamba 

### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [ ]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
