### PR TITLE
init command: Ensure program path is always made absolute

### DIFF
--- a/news/20200816123120.bugfix
+++ b/news/20200816123120.bugfix
@@ -1,0 +1,1 @@
+Ensure program path is always made absolute on Windows.

--- a/src/mbed_tools/project/_internal/project_data.py
+++ b/src/mbed_tools/project/_internal/project_data.py
@@ -88,9 +88,6 @@ class MbedProgramFiles:
 
         Args:
             root_path: The path containing the MbedProgramFiles.
-
-        Raises:
-            ValueError: No MbedProgramFiles exist at this path.
         """
         app_config: Optional[Path]
         app_config = root_path / APP_CONFIG_FILE_NAME

--- a/src/mbed_tools/project/_internal/templates/CMakeLists.tmpl
+++ b/src/mbed_tools/project/_internal/templates/CMakeLists.tmpl
@@ -13,13 +13,15 @@ add_executable(${APP_TARGET}
     main.cpp
 )
 
-mbed_os_target_linker_script(${APP_TARGET})
+mbed_configure_app_target(${APP_TARGET})
+
+mbed_set_mbed_target_linker_script(${APP_TARGET})
 
 project(${APP_TARGET})
 
 target_link_libraries(${APP_TARGET} mbed-os)
 
-mbed_os_bin_hex(${APP_TARGET})
+mbed_generate_bin_hex(${APP_TARGET})
 
 option(VERBOSE_BUILD "Have a verbose build process")
 if(VERBOSE_BUILD)

--- a/src/mbed_tools/project/mbed_program.py
+++ b/src/mbed_tools/project/mbed_program.py
@@ -196,7 +196,7 @@ def _find_program_root(cwd: Path) -> Path:
     Returns:
         Path containing the mbed-os.lib file.
     """
-    potential_root = cwd.resolve()
+    potential_root = cwd.absolute().resolve()
     while str(potential_root) != str(potential_root.anchor):
         logger.debug(f"Searching for mbed-os.lib file at path {potential_root}")
         root_file = potential_root / MBED_OS_REFERENCE_FILE_NAME

--- a/tests/project/_internal/test_mbed_program.py
+++ b/tests/project/_internal/test_mbed_program.py
@@ -2,6 +2,7 @@
 # Copyright (C) 2020 Arm Mbed. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
+import os
 import pathlib
 
 from unittest import mock, TestCase
@@ -24,10 +25,36 @@ class TestInitialiseProgram(TestCase):
             MbedProgram.from_new(program_root)
 
     @patchfs
-    def test_from_new_local_dir_generates_valid_program(self, fs):
+    def test_from_new_local_dir_generates_valid_program_creating_directory(self, fs):
         fs_root = pathlib.Path(fs, "foo")
         fs_root.mkdir()
         program_root = fs_root / "programfoo"
+
+        program = MbedProgram.from_new(program_root)
+
+        self.assertEqual(program.files, MbedProgramFiles.from_existing(program_root))
+
+    @patchfs
+    def test_from_new_local_dir_generates_valid_program_creating_directory_in_cwd(self, fs):
+        old_cwd = os.getcwd()
+        try:
+            fs_root = pathlib.Path(fs, "foo")
+            fs_root.mkdir()
+            os.chdir(fs_root)
+            program_root = pathlib.Path("programfoo")
+
+            program = MbedProgram.from_new(program_root)
+
+            self.assertEqual(program.files, MbedProgramFiles.from_existing(program_root))
+        finally:
+            os.chdir(old_cwd)
+
+    @patchfs
+    def test_from_new_local_dir_generates_valid_program_existing_directory(self, fs):
+        fs_root = pathlib.Path(fs, "foo")
+        fs_root.mkdir()
+        program_root = fs_root / "programfoo"
+        program_root.mkdir()
 
         program = MbedProgram.from_new(program_root)
 


### PR DESCRIPTION
### Description

<!--
Please add any detail or context that would be useful to a reviewer.
-->
`pathlib.Path.resolve` doesn't make a nonexistent path absolute on Windows.

To fix this call `Path.absolute`, and then resolve any symlinks in the
absolute path to get the canonical potential path to the directory.

### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [x]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
