### PR TITLE
Template: fix Mbed OS CMake function calls

### DIFF
--- a/src/mbed_tools/project/_internal/templates/CMakeLists.tmpl
+++ b/src/mbed_tools/project/_internal/templates/CMakeLists.tmpl
@@ -9,17 +9,22 @@ set(APP_TARGET {{program_name}})
 
 add_subdirectory(${MBED_ROOT})
 
-add_executable(${APP_TARGET}
-    main.cpp
-)
+add_executable(${APP_TARGET})
 
-mbed_os_target_linker_script(${APP_TARGET})
+mbed_configure_app_target(${APP_TARGET})
+
+mbed_set_mbed_target_linker_script(${APP_TARGET})
 
 project(${APP_TARGET})
 
+target_sources(${APP_TARGET}
+    PRIVATE
+        main.cpp
+)
+
 target_link_libraries(${APP_TARGET} mbed-os)
 
-mbed_os_bin_hex(${APP_TARGET})
+mbed_generate_bin_hex(${APP_TARGET})
 
 option(VERBOSE_BUILD "Have a verbose build process")
 if(VERBOSE_BUILD)


### PR DESCRIPTION
### Description

<!--
Please add any detail or context that would be useful to a reviewer.
-->

* Correct the calls to Mbed OS provided CMake functions which had been
  renamed.
* Also include application source file(s) using the recommended
  `target_sources` CMake function.


### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [x]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
