### PR TITLE
Fix the "Sync Board Database" nightly CI job

### DIFF
--- a/ci_scripts/sync_board_database.py
+++ b/ci_scripts/sync_board_database.py
@@ -65,7 +65,7 @@ def save_board_database(board_database_text: str, output_file_path: Path) -> Non
     output_file_path.write_text(board_database_text)
 
 
-def get_boards_added_or_removed(offline_boards: Boards, online_boards: Boards) -> DatabaseUpdateResult:
+def determine_board_database_update_result(offline_boards: Boards, online_boards: Boards) -> DatabaseUpdateResult:
     """Check boards added and removed in relation to the offline board database."""
     added = online_boards - offline_boards
     removed = offline_boards - online_boards
@@ -153,7 +153,7 @@ def main(args: argparse.Namespace) -> int:
         online_boards = Boards.from_online_database()
         if BOARD_DATABASE_PATH.exists():
             offline_boards = Boards.from_offline_database()
-            result = get_boards_added_or_removed(offline_boards, online_boards)
+            result = determine_board_database_update_result(offline_boards, online_boards)
             if not (result.boards_added or result.boards_removed):
                 logger.info("No changes to commit. Exiting.")
                 return 0

--- a/ci_scripts/sync_board_database.py
+++ b/ci_scripts/sync_board_database.py
@@ -26,14 +26,12 @@ from mbed_tools_ci_scripts.utils.configuration import configuration, Configurati
 from mbed_tools.lib.exceptions import ToolsError
 from mbed_tools.lib.logging import log_exception, set_log_level
 
-from mbed_tools.targets._internal.board_database import SNAPSHOT_FILENAME
+from mbed_tools.targets._internal.board_database import get_board_database_path
 from mbed_tools.targets.boards import Boards
 
 logger = logging.getLogger()
 
-BOARD_DATABASE_PATH = Path(
-    configuration.get_value(ConfigurationVariable.PROJECT_ROOT), "mbed_targets", "_internal", "data", SNAPSHOT_FILENAME,
-)
+BOARD_DATABASE_PATH = get_board_database_path()
 
 
 class PullRequestInfo(NamedTuple):

--- a/news/20200817142518.misc
+++ b/news/20200817142518.misc
@@ -1,0 +1,1 @@
+Fix Sync Board Database CI job.

--- a/tests/ci_scripts/test_sync_board_db.py
+++ b/tests/ci_scripts/test_sync_board_db.py
@@ -101,21 +101,21 @@ def _make_mbed_boards_for_diff(boards_a, boards_b):
 class TestSyncBoardDB(TestCase):
     def test_get_boards_added_or_removed_detects_added(self):
         mock_online_boards, mock_offline_boards = _make_mbed_boards_for_diff([BOARD_1, BOARD_2], [BOARD_1])
-        added, removed = sync_board_database.get_boards_added_or_removed(mock_offline_boards, mock_online_boards)
-        self.assertEqual(len(added), 1, "Expect one new board to be added to offline db.")
-        self.assertEqual(len(removed), 0, "Expect no boards to be removed from offline db.")
+        result = sync_board_database.get_boards_added_or_removed(mock_offline_boards, mock_online_boards)
+        self.assertEqual(len(result.boards_added), 1, "Expect one new board to be added to offline db.")
+        self.assertEqual(len(result.boards_removed), 0, "Expect no boards to be removed from offline db.")
 
     def test_get_boards_added_or_removed_detects_removed(self):
         mock_offline_boards, mock_online_boards = _make_mbed_boards_for_diff([BOARD_1, BOARD_2], [BOARD_1])
-        added, removed = sync_board_database.get_boards_added_or_removed(mock_offline_boards, mock_online_boards)
-        self.assertEqual(len(added), 0, "Expect no boards to be added to offline db.")
-        self.assertEqual(len(removed), 1, "Expect one board to be removed from offline db.")
+        result = sync_board_database.get_boards_added_or_removed(mock_offline_boards, mock_online_boards)
+        self.assertEqual(len(result.boards_added), 0, "Expect no boards to be added to offline db.")
+        self.assertEqual(len(result.boards_removed), 1, "Expect one board to be removed from offline db.")
 
     def test_get_boards_added_or_removed_returns_empty_containers_when_no_change(self):
         mock_offline_boards, mock_online_boards = _make_mbed_boards_for_diff([BOARD_1], [BOARD_1])
-        added, removed = sync_board_database.get_boards_added_or_removed(mock_offline_boards, mock_online_boards)
-        self.assertEqual(len(added), 0, "Returns an empty targets container when no targets added")
-        self.assertEqual(len(removed), 0, "Returns an empty targets container when no targets removed.")
+        result = sync_board_database.get_boards_added_or_removed(mock_offline_boards, mock_online_boards)
+        self.assertEqual(len(result.boards_added), 0, "Returns an empty targets container when no targets added")
+        self.assertEqual(len(result.boards_removed), 0, "Returns an empty targets container when no targets removed.")
 
     def test_news_file_item_text_formatting(self):
         with mock.patch("ci_scripts.sync_board_database.Path", autospec=True) as mock_path:

--- a/tests/ci_scripts/test_sync_board_db.py
+++ b/tests/ci_scripts/test_sync_board_db.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 """Tests for sync_board_database.py."""
-from unittest import TestCase, mock
+from unittest import TestCase
 
 from ci_scripts import sync_board_database
 
@@ -98,30 +98,30 @@ def _make_mbed_boards_for_diff(boards_a, boards_b):
     )
 
 
-class TestSyncBoardDB(TestCase):
-    def test_get_boards_added_or_removed_detects_added(self):
+class TestDetermineBoardDatabaseUpdateResult(TestCase):
+    def test_detects_added(self):
         mock_online_boards, mock_offline_boards = _make_mbed_boards_for_diff([BOARD_1, BOARD_2], [BOARD_1])
-        result = sync_board_database.get_boards_added_or_removed(mock_offline_boards, mock_online_boards)
+        result = sync_board_database.determine_board_database_update_result(mock_offline_boards, mock_online_boards)
         self.assertEqual(len(result.boards_added), 1, "Expect one new board to be added to offline db.")
         self.assertEqual(len(result.boards_removed), 0, "Expect no boards to be removed from offline db.")
 
-    def test_get_boards_added_or_removed_detects_removed(self):
+    def test_detects_removed(self):
         mock_offline_boards, mock_online_boards = _make_mbed_boards_for_diff([BOARD_1, BOARD_2], [BOARD_1])
-        result = sync_board_database.get_boards_added_or_removed(mock_offline_boards, mock_online_boards)
+        result = sync_board_database.determine_board_database_update_result(mock_offline_boards, mock_online_boards)
         self.assertEqual(len(result.boards_added), 0, "Expect no boards to be added to offline db.")
         self.assertEqual(len(result.boards_removed), 1, "Expect one board to be removed from offline db.")
 
-    def test_get_boards_added_or_removed_returns_empty_containers_when_no_change(self):
+    def test_returns_empty_when_no_change(self):
         mock_offline_boards, mock_online_boards = _make_mbed_boards_for_diff([BOARD_1], [BOARD_1])
-        result = sync_board_database.get_boards_added_or_removed(mock_offline_boards, mock_online_boards)
+        result = sync_board_database.determine_board_database_update_result(mock_offline_boards, mock_online_boards)
         self.assertEqual(len(result.boards_added), 0, "Returns an empty targets container when no targets added")
         self.assertEqual(len(result.boards_removed), 0, "Returns an empty targets container when no targets removed.")
 
-    def test_news_file_item_text_formatting(self):
-        with mock.patch("ci_scripts.sync_board_database.Path", autospec=True) as mock_path:
-            mock_path().exists.return_value = False
-            text = sync_board_database.create_news_item_text(
-                "New boards added:",
-                Boards([Board.from_online_board_entry(BOARD_1), Board.from_online_board_entry(BOARD_2)]),
-            )
-            self.assertEqual(text, "New boards added: u-blox NINA-B1, Multitech xDOT", "Text is formatted correctly.")
+
+class TestCreateNewsItemText(TestCase):
+    def test_text_formatting(self):
+        text = sync_board_database.create_news_item_text(
+            "New boards added:",
+            Boards([Board.from_online_board_entry(BOARD_1), Board.from_online_board_entry(BOARD_2)]),
+        )
+        self.assertEqual(text, "New boards added: u-blox NINA-B1, Multitech xDOT", "Text is formatted correctly.")

--- a/tests/ci_scripts/test_sync_board_db.py
+++ b/tests/ci_scripts/test_sync_board_db.py
@@ -98,6 +98,11 @@ def _make_mbed_boards_for_diff(boards_a, boards_b):
     )
 
 
+class TestBoardDatabasePath(TestCase):
+    def test_board_database_path_exists(self):
+        self.assertTrue(sync_board_database.BOARD_DATABASE_PATH.exists())
+
+
 class TestDetermineBoardDatabaseUpdateResult(TestCase):
     def test_detects_added(self):
         mock_online_boards, mock_offline_boards = _make_mbed_boards_for_diff([BOARD_1, BOARD_2], [BOARD_1])

--- a/tests/ci_scripts/test_sync_board_db.py
+++ b/tests/ci_scripts/test_sync_board_db.py
@@ -123,10 +123,39 @@ class TestDetermineBoardDatabaseUpdateResult(TestCase):
         self.assertEqual(len(result.boards_removed), 0, "Returns an empty targets container when no targets removed.")
 
 
-class TestCreateNewsItemText(TestCase):
-    def test_text_formatting(self):
-        text = sync_board_database.create_news_item_text(
-            "New boards added:",
-            Boards([Board.from_online_board_entry(BOARD_1), Board.from_online_board_entry(BOARD_2)]),
+class TestCreateNewsFileTextFromResult(TestCase):
+    def test_text_formatting_for_boards_added(self):
+        mock_online_boards, mock_offline_boards = _make_mbed_boards_for_diff([BOARD_1, BOARD_2], [])
+        result = sync_board_database.determine_board_database_update_result(
+            online_boards=mock_online_boards, offline_boards=mock_offline_boards
         )
-        self.assertEqual(text, "New boards added: u-blox NINA-B1, Multitech xDOT", "Text is formatted correctly.")
+        text = sync_board_database.create_news_file_text_from_result(result)
+        self.assertEqual(
+            text,
+            f"Targets added: {BOARD_1['attributes']['name']}, {BOARD_2['attributes']['name']}.\n",
+            "Text is formatted correctly.",
+        )
+
+    def test_text_formatting_for_boards_removed(self):
+        mock_online_boards, mock_offline_boards = _make_mbed_boards_for_diff([], [BOARD_1, BOARD_2])
+        result = sync_board_database.determine_board_database_update_result(
+            online_boards=mock_online_boards, offline_boards=mock_offline_boards
+        )
+        text = sync_board_database.create_news_file_text_from_result(result)
+        self.assertEqual(
+            text,
+            f"Targets removed: {BOARD_1['attributes']['name']}, {BOARD_2['attributes']['name']}.\n",
+            "Text is formatted correctly.",
+        )
+
+    def test_text_formatting_for_boards_added_and_removed(self):
+        mock_online_boards, mock_offline_boards = _make_mbed_boards_for_diff([BOARD_1], [BOARD_2])
+        result = sync_board_database.determine_board_database_update_result(
+            online_boards=mock_online_boards, offline_boards=mock_offline_boards
+        )
+        text = sync_board_database.create_news_file_text_from_result(result)
+        self.assertEqual(
+            text,
+            f"Targets added: {BOARD_1['attributes']['name']}.\nTargets removed: {BOARD_2['attributes']['name']}.\n",
+            "Text is formatted correctly.",
+        )

--- a/tests/ci_scripts/test_sync_board_db.py
+++ b/tests/ci_scripts/test_sync_board_db.py
@@ -90,6 +90,78 @@ BOARD_2 = {
     },
 }
 
+BOARD_3 = {
+    "type": "target",
+    "id": "3",
+    "attributes": {
+        "features": {
+            "mbed_enabled": ["Advanced"],
+            "mbed_os_support": [
+                "Mbed OS 5.10",
+                "Mbed OS 5.11",
+                "Mbed OS 5.12",
+                "Mbed OS 5.13",
+                "Mbed OS 5.14",
+                "Mbed OS 5.15",
+                "Mbed OS 5.7",
+                "Mbed OS 5.8",
+                "Mbed OS 5.9",
+            ],
+            "antenna": ["Connector"],
+            "certification": ["CE (Europe)", "FCC/CFR (USA)", "IC RSS (Canada)", "NCC (Taiwan)"],
+            "communication": ["LoRa"],
+            "interface_firmware": ["DAPLink"],
+            "security": ["TRNG"],
+            "target_core": ["Cortex-M4"],
+            "mbed_studio_support": ["Build and run"],
+        },
+        "board_type": "ADV_WISE_1510",
+        "flash_size": 256,
+        "name": "Advantech WISE-1510",
+        "product_code": "0458",
+        "ram_size": 64,
+        "target_type": "module",
+        "hidden": False,
+        "device_name": "STM32L443RC",
+        "slug": "advantech-wise-1510",
+    },
+}
+
+BOARD_2_MODIFIED = {
+    "type": "target",
+    "id": "2",
+    "attributes": {
+        "features": {
+            "mbed_enabled": ["Advanced"],
+            "mbed_os_support": [
+                "Mbed OS 6.2",
+                "Mbed OS 5.10",
+                "Mbed OS 5.11",
+                "Mbed OS 5.12",
+                "Mbed OS 5.13",
+                "Mbed OS 5.14",
+                "Mbed OS 5.15",
+                "Mbed OS 5.8",
+                "Mbed OS 5.9",
+            ],
+            "antenna": ["Connector"],
+            "certification": ["AS/NZS (Australia and New Zealand)", "CE (Europe)", "FCC/CFR (USA)", "IC RSS (Canada)"],
+            "communication": ["LoRa"],
+            "interface_firmware": ["DAPLink"],
+            "target_core": ["Cortex-M3"],
+            "mbed_studio_support": ["Build and run"],
+        },
+        "board_type": "MTB_MTS_XDOT",
+        "flash_size": 256,
+        "name": "Multitech xDOT",
+        "product_code": "0453",
+        "ram_size": 64,
+        "target_type": "module",
+        "hidden": False,
+        "device_name": "STM32L151CC",
+    },
+}
+
 
 def _make_mbed_boards_for_diff(boards_a, boards_b):
     return (
@@ -116,6 +188,24 @@ class TestDetermineBoardDatabaseUpdateResult(TestCase):
         self.assertEqual(len(result.boards_added), 0, "Expect no boards to be added to offline db.")
         self.assertEqual(len(result.boards_removed), 1, "Expect one board to be removed from offline db.")
 
+    def test_detects_modified(self):
+        mock_offline_boards, mock_online_boards = _make_mbed_boards_for_diff(
+            [BOARD_1, BOARD_2], [BOARD_1, BOARD_2_MODIFIED]
+        )
+        result = sync_board_database.determine_board_database_update_result(mock_offline_boards, mock_online_boards)
+        self.assertEqual(len(result.boards_modified), 1)
+        self.assertEqual(len(result.boards_added), 0)
+        self.assertEqual(len(result.boards_removed), 0)
+
+    def test_detects_added_removed_and_modified(self):
+        mock_online_boards, mock_offline_boards = _make_mbed_boards_for_diff(
+            [BOARD_3, BOARD_2], [BOARD_1, BOARD_2_MODIFIED]
+        )
+        result = sync_board_database.determine_board_database_update_result(mock_offline_boards, mock_online_boards)
+        self.assertEqual(len(result.boards_modified), 1)
+        self.assertEqual(len(result.boards_added), 1)
+        self.assertEqual(len(result.boards_removed), 1)
+
     def test_returns_empty_when_no_change(self):
         mock_offline_boards, mock_online_boards = _make_mbed_boards_for_diff([BOARD_1], [BOARD_1])
         result = sync_board_database.determine_board_database_update_result(mock_offline_boards, mock_online_boards)
@@ -132,7 +222,7 @@ class TestCreateNewsFileTextFromResult(TestCase):
         text = sync_board_database.create_news_file_text_from_result(result)
         self.assertEqual(
             text,
-            f"Targets added: {BOARD_1['attributes']['name']}, {BOARD_2['attributes']['name']}.\n",
+            f"Targets added: {BOARD_2['attributes']['name']}, {BOARD_1['attributes']['name']}.\n",
             "Text is formatted correctly.",
         )
 
@@ -144,18 +234,31 @@ class TestCreateNewsFileTextFromResult(TestCase):
         text = sync_board_database.create_news_file_text_from_result(result)
         self.assertEqual(
             text,
-            f"Targets removed: {BOARD_1['attributes']['name']}, {BOARD_2['attributes']['name']}.\n",
+            f"Targets removed: {BOARD_2['attributes']['name']}, {BOARD_1['attributes']['name']}.\n",
             "Text is formatted correctly.",
         )
 
-    def test_text_formatting_for_boards_added_and_removed(self):
-        mock_online_boards, mock_offline_boards = _make_mbed_boards_for_diff([BOARD_1], [BOARD_2])
+    def test_text_formatting_for_boards_modified(self):
+        mock_online_boards, mock_offline_boards = _make_mbed_boards_for_diff([BOARD_2], [BOARD_2_MODIFIED])
+        result = sync_board_database.determine_board_database_update_result(
+            online_boards=mock_online_boards, offline_boards=mock_offline_boards
+        )
+        text = sync_board_database.create_news_file_text_from_result(result)
+        self.assertEqual(
+            text, f"Targets modified: {BOARD_2['attributes']['name']}.\n", "Text is formatted correctly.",
+        )
+
+    def test_text_formatting_for_boards_added_removed_and_modified(self):
+        mock_online_boards, mock_offline_boards = _make_mbed_boards_for_diff(
+            [BOARD_3, BOARD_2], [BOARD_1, BOARD_2_MODIFIED]
+        )
         result = sync_board_database.determine_board_database_update_result(
             online_boards=mock_online_boards, offline_boards=mock_offline_boards
         )
         text = sync_board_database.create_news_file_text_from_result(result)
         self.assertEqual(
             text,
-            f"Targets added: {BOARD_1['attributes']['name']}.\nTargets removed: {BOARD_2['attributes']['name']}.\n",
+            f"Targets added: {BOARD_3['attributes']['name']}.\nTargets removed: {BOARD_1['attributes']['name']}.\n"
+            f"Targets modified: {BOARD_2['attributes']['name']}.\n",
             "Text is formatted correctly.",
         )


### PR DESCRIPTION
### Description

<!--
Please add any detail or context that would be useful to a reviewer.
-->
The job was failing because it was looking in the wrong place for the board database snapshot.

Also improve news item text formatting and handle "modified" targets.


### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [x]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
