### PR TITLE
Remove `MBED_BUILD_TIMESTAMP` config option

### DIFF
--- a/news/20200819144454.bugfix
+++ b/news/20200819144454.bugfix
@@ -1,0 +1,1 @@
+Remove MBED_BUILD_TIMESTAMP config option

--- a/src/mbed_tools/build/_internal/cmake_file.py
+++ b/src/mbed_tools/build/_internal/cmake_file.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 """Module in charge of CMake file generation."""
-import datetime
 import pathlib
 from typing import Iterable
 
@@ -60,7 +59,6 @@ def _render_mbed_config_cmake_template(
         "target_macros": target_build_attributes["macros"],
         "supported_form_factors": target_build_attributes["supported_form_factors"],
         "core": target_build_attributes["core"],
-        "timestamp": datetime.datetime.now().timestamp(),
         "target_name": target_name,
         "toolchain_name": toolchain_name,
         "options": sorted(options, key=lambda option: option.macro_name),

--- a/src/mbed_tools/build/_internal/templates/mbed_config.tmpl
+++ b/src/mbed_tools/build/_internal/templates/mbed_config.tmpl
@@ -44,7 +44,6 @@ set(MBED_TARGET_DEFINITIONS{% for component in components %}
 {% for form_factor in supported_form_factors %}
     TARGET_FF_{{form_factor}}
 {%- endfor %}
-    MBED_BUILD_TIMESTAMP={{timestamp}}
     TARGET_LIKE_MBED
     __MBED__=1
 )

--- a/tests/build/_internal/test_cmake_file.py
+++ b/tests/build/_internal/test_cmake_file.py
@@ -2,15 +2,14 @@
 # Copyright (C) 2020 Arm Mbed. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
-from unittest import TestCase, mock
+from unittest import TestCase
 
 from tests.build._internal.config.factories import ConfigFactory
 from mbed_tools.build._internal.cmake_file import generate_mbed_config_cmake_file, _render_mbed_config_cmake_template
 
 
 class TestGenerateCMakeListsFile(TestCase):
-    @mock.patch("mbed_tools.build._internal.cmake_file.datetime")
-    def test_correct_arguments_passed(self, datetime):
+    def test_correct_arguments_passed(self):
         target = dict()
         target["labels"] = ["foo"]
         target["extra_labels"] = ["morefoo"]
@@ -20,8 +19,6 @@ class TestGenerateCMakeListsFile(TestCase):
         target["device_has"] = ["stuff"]
         target["core"] = ["core"]
         target["supported_form_factors"] = ["arduino"]
-        datetime = mock.Mock()
-        datetime.datetime.now.return_value.timestamp.return_value = 2
         config = ConfigFactory()
         mbed_target = "K64F"
         toolchain_name = "GCC"


### PR DESCRIPTION
### Description
The config option `MBED_BUILD_TIMESTAMP` is not used by Mbed OS. But it
is always generated by `mbedtools configure` and for every run
time stamp is different. During build, `MBED_BUILD_TIMESTAMP` is passed
as command line parameter. Due to this, every call to
`mbedtools configure` leads to`ccache` cache miss.

<!--
Please add any detail or context that would be useful to a reviewer.
-->



### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [x]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
