### PR TITLE
config: Add CMake printf variable and C library variables to the generated CMake module

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -7,7 +7,7 @@ verify_ssl = true
 mbed-tools = {editable = true, path = "."}
 
 [dev-packages]
-black = "*"
+black = "==19.10b0"
 coverage = "*"
 flake8 = "*"
 flake8-docstrings = "*"

--- a/news/20200915.feature
+++ b/news/20200915.feature
@@ -1,0 +1,1 @@
+Add CMake variables for the selected printf and C library to the generated CMake module

--- a/src/mbed_tools/build/_internal/cmake_file.py
+++ b/src/mbed_tools/build/_internal/cmake_file.py
@@ -49,6 +49,7 @@ def _render_mbed_config_cmake_template(
     template = env.get_template(TEMPLATE_NAME)
     options = list(config.options.values())
     macros = list(config.macros.values())
+    supported_c_libs = [x for x in target_build_attributes["supported_c_libs"][toolchain_name.lower()]]
 
     context = {
         "labels": target_build_attributes["labels"],
@@ -58,7 +59,10 @@ def _render_mbed_config_cmake_template(
         "device_has": target_build_attributes["device_has"],
         "target_macros": target_build_attributes["macros"],
         "supported_form_factors": target_build_attributes["supported_form_factors"],
+        "supported_c_libs": supported_c_libs,
+        "c_lib": target_build_attributes["c_lib"],
         "core": target_build_attributes["core"],
+        "printf_lib": target_build_attributes["printf_lib"],
         "target_name": target_name,
         "toolchain_name": toolchain_name,
         "options": sorted(options, key=lambda option: option.macro_name),

--- a/src/mbed_tools/build/_internal/templates/mbed_config.tmpl
+++ b/src/mbed_tools/build/_internal/templates/mbed_config.tmpl
@@ -7,6 +7,13 @@
 set(MBED_TOOLCHAIN "{{toolchain_name}}" CACHE STRING "")
 set(MBED_TARGET "{{target_name}}" CACHE STRING "")
 set(MBED_CPU_CORE "{{core}}" CACHE STRING "")
+set(MBED_C_LIB "{{c_lib}}" CACHE STRING "")
+set(MBED_PRINTF_LIB "{{printf_lib}}" CACHE STRING "")
+
+list(APPEND MBED_TARGET_SUPPORTED_C_LIBS {% for supported_c_lib in supported_c_libs %}
+    {{supported_c_lib}}
+{%- endfor %}
+)
 
 list(APPEND MBED_TARGET_LABELS{% for label in labels %}
     {{label}}

--- a/tests/build/_internal/test_cmake_file.py
+++ b/tests/build/_internal/test_cmake_file.py
@@ -17,11 +17,14 @@ class TestGenerateCMakeListsFile(TestCase):
         target["components"] = ["baz"]
         target["macros"] = ["macbaz"]
         target["device_has"] = ["stuff"]
+        target["c_lib"] = ["c_lib"]
         target["core"] = ["core"]
+        target["printf_lib"] = ["printf_lib"]
         target["supported_form_factors"] = ["arduino"]
         config = ConfigFactory()
         mbed_target = "K64F"
         toolchain_name = "GCC"
+        target["supported_c_libs"] = {toolchain_name.lower(): ["small", "std"]}
 
         result = generate_mbed_config_cmake_file(mbed_target, target, config, toolchain_name)
 
@@ -40,9 +43,12 @@ class TestRendersCMakeListsFile(TestCase):
         target["macros"] = ["macbaz"]
         target["device_has"] = ["stuff"]
         target["core"] = ["core"]
+        target["c_lib"] = ["c_lib"]
+        target["printf_lib"] = ["printf_lib"]
         target["supported_form_factors"] = ["arduino"]
         config = ConfigFactory()
         toolchain_name = "baz"
+        target["supported_c_libs"] = {toolchain_name.lower(): ["small", "std"]}
         result = _render_mbed_config_cmake_template(target, config, toolchain_name, "target_name")
 
         for label in target["labels"] + target["extra_labels"]:
@@ -50,3 +56,8 @@ class TestRendersCMakeListsFile(TestCase):
 
         for macro in target["features"] + target["components"] + [toolchain_name]:
             self.assertIn(macro, result)
+
+        for toolchain in target["supported_c_libs"]:
+            self.assertIn(toolchain, result)
+            for supported_c_libs in toolchain:
+                self.assertIn(supported_c_libs, result)


### PR DESCRIPTION
`MBED_TARGET_SUPPORTED_C_LIBS`, `MBED_PRINTF_LIB` and `MBED_C_LIB` are provided
in the generated configuration CMake module to allow the toolchain to be
configured for the selected printf library and C library.

### Description

<!--
Please add any detail or context that would be useful to a reviewer.
-->



### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [X]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
