### PR TITLE
Add build command porcelain

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,7 +58,7 @@ matrix:
         - cd ..
         - _clone_dependencies
       script:
-        - _config_and_build
+        - mbedtools build -t GCC_ARM -m ${TARGET_NAME}
         - ccache -s
 
     - <<: *mbed-tools-test

--- a/news/20200929104817.feature
+++ b/news/20200929104817.feature
@@ -1,0 +1,1 @@
+Add build command porcelain to build an Mbed project using CMake and Ninja.

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,6 +26,8 @@ check_untyped_defs = True
 [flake8]
 exclude =
     .git,
+    .tox,
+    .venv,
     __pycache__,
     docs,
     news,

--- a/src/mbed_tools/build/__init__.py
+++ b/src/mbed_tools/build/__init__.py
@@ -10,3 +10,4 @@ The functionality covered in this package includes the following:
 - Invocation of the build process for the command line tools and online build service.
 - Export of build instructions to third party command line tools and IDEs.
 """
+from mbed_tools.build.config import generate_config

--- a/src/mbed_tools/build/__init__.py
+++ b/src/mbed_tools/build/__init__.py
@@ -10,4 +10,5 @@ The functionality covered in this package includes the following:
 - Invocation of the build process for the command line tools and online build service.
 - Export of build instructions to third party command line tools and IDEs.
 """
+from mbed_tools.build.build import build_project, generate_build_system
 from mbed_tools.build.config import generate_config

--- a/src/mbed_tools/build/build.py
+++ b/src/mbed_tools/build/build.py
@@ -1,0 +1,40 @@
+#
+# Copyright (C) 2020 Arm Mbed. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+"""Configure and build a CMake project."""
+import pathlib
+import subprocess
+
+from typing import Optional
+
+from mbed_tools.build.exceptions import MbedBuildError
+
+
+def build_project(build_dir: pathlib.Path, target: Optional[str] = None) -> None:
+    """Build a project using CMake to invoke Ninja.
+
+    Args:
+        build_dir: Path to the CMake build tree.
+        target: The CMake target to build (e.g 'install')
+    """
+    target_flag = ["--target", target] if target is not None else []
+    _cmake_wrapper("--build", str(build_dir), *target_flag)
+
+
+def generate_build_system(source_dir: pathlib.Path, build_dir: pathlib.Path, profile: str) -> None:
+    """Configure a project using CMake.
+
+    Args:
+        source_dir: Path to the CMake source tree.
+        build_dir: Path to the CMake build tree.
+        profile: The Mbed build profile (develop, debug or release).
+    """
+    _cmake_wrapper("-S", str(source_dir), "-B", str(build_dir), "-GNinja", f"-DCMAKE_BUILD_TYPE={profile}")
+
+
+def _cmake_wrapper(*cmake_args: str) -> None:
+    try:
+        subprocess.run(["cmake", *cmake_args], check=True)
+    except subprocess.CalledProcessError:
+        raise MbedBuildError("CMake invocation failed!")

--- a/src/mbed_tools/build/config.py
+++ b/src/mbed_tools/build/config.py
@@ -1,0 +1,31 @@
+#
+# Copyright (C) 2020 Arm Mbed. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+"""Parses the Mbed configuration system and generates a CMake config script."""
+import pathlib
+
+from mbed_tools.project import MbedProgram
+from mbed_tools.targets import get_target_by_name
+from mbed_tools.build._internal.cmake_file import generate_mbed_config_cmake_file
+from mbed_tools.build._internal.config.assemble_build_config import assemble_config
+from mbed_tools.build._internal.write_files import write_file
+
+
+def generate_config(target_name: str, toolchain: str, program: MbedProgram) -> pathlib.Path:
+    """Generate an Mbed config file at the program root by parsing the mbed config system.
+
+    Args:
+        target_name: Name of the target to configure for.
+        toolchain: Name of the toolchain to use.
+        program: The MbedProgram to configure.
+
+    Returns:
+        Path to the generated config file.
+    """
+    target_build_attributes = get_target_by_name(target_name, program.mbed_os.targets_json_file)
+    config = assemble_config(target_build_attributes, program.root, program.files.app_config_file)
+    cmake_file_contents = generate_mbed_config_cmake_file(target_name, target_build_attributes, config, toolchain)
+    cmake_config_file_path = program.files.cmake_config_file
+    write_file(cmake_config_file_path.parent, cmake_config_file_path.name, cmake_file_contents)
+    return cmake_config_file_path

--- a/src/mbed_tools/cli/build.py
+++ b/src/mbed_tools/cli/build.py
@@ -1,0 +1,63 @@
+#
+# Copyright (C) 2020 Arm Mbed. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+"""Command to build an Mbed project using CMake."""
+import os
+import pathlib
+
+import click
+
+from mbed_tools.build import build_project, generate_build_system, generate_config
+from mbed_tools.project import MbedProgram
+
+
+@click.command(name="build", help="Build an Mbed project.")
+@click.option(
+    "-t",
+    "--toolchain",
+    type=click.Choice(["ARM", "GCC_ARM"], case_sensitive=False),
+    help="The toolchain you are using to build your app.",
+)
+@click.option("-m", "--mbed-target", help="A build target for an Mbed-enabled device, e.g. K64F.")
+@click.option("-b", "--build-type", default="develop", help="The build type (release, develop or debug).")
+@click.option("-c", "--clean", is_flag=True, default=False, help="Perform a 'clean' build.")
+@click.option(
+    "-p",
+    "--program-path",
+    default=os.getcwd(),
+    help="Path to local Mbed program. By default it is the current working directory.",
+)
+def build(program_path: str, build_type: str, toolchain: str = "", mbed_target: str = "", clean: bool = False) -> None:
+    """Configure and build an Mbed project using CMake and Ninja.
+
+    If the project has already been configured and contains '.mbedbuild/mbed_config.cmake', this command will skip the
+    Mbed configuration step and invoke CMake.
+
+    If the CMake configuration step has already been run previously (i.e a CMake build tree exists), then just try to
+    build the project immediately using Ninja.
+
+    Args:
+       program_path: Path to the Mbed project.
+       build_type: The Mbed build profile (debug, develop or release).
+       toolchain: The toolchain to use for the build.
+       mbed_target: The name of the Mbed target to build for.
+       clean: Force regeneration of config and build system before building.
+    """
+    program = MbedProgram.from_existing(pathlib.Path(program_path))
+    mbed_config_file = program.files.cmake_config_file
+    if not mbed_config_file.exists() or clean:
+        click.echo("Generating Mbed config...")
+        if not toolchain:
+            raise click.UsageError("--toolchain argument is required when generating Mbed config!")
+
+        if not mbed_target:
+            raise click.UsageError("--mbed-target argument is required when generating Mbed config!")
+
+        generate_config(mbed_target.upper(), toolchain, program)
+
+    build_tree = program.files.cmake_build_dir
+    if not build_tree.exists() or clean:
+        generate_build_system(program.root, build_tree, build_type)
+
+    build_project(build_tree)

--- a/src/mbed_tools/cli/configure.py
+++ b/src/mbed_tools/cli/configure.py
@@ -8,10 +8,7 @@ import pathlib
 import click
 
 from mbed_tools.project import MbedProgram
-from mbed_tools.targets import get_target_by_name
-from mbed_tools.build._internal.cmake_file import generate_mbed_config_cmake_file
-from mbed_tools.build._internal.config.assemble_build_config import assemble_config
-from mbed_tools.build._internal.write_files import write_file
+from mbed_tools.build import generate_config
 
 
 @click.command(
@@ -49,9 +46,5 @@ def configure(toolchain: str, mbed_target: str, program_path: str) -> None:
     """
     program = MbedProgram.from_existing(pathlib.Path(program_path))
     mbed_target = mbed_target.upper()
-    target_build_attributes = get_target_by_name(mbed_target, program.mbed_os.targets_json_file)
-    config = assemble_config(target_build_attributes, program.root, program.files.app_config_file)
-    cmake_file_contents = generate_mbed_config_cmake_file(mbed_target, target_build_attributes, config, toolchain)
-    output_directory = program.root / ".mbedbuild"
-    write_file(output_directory, "mbed_config.cmake", cmake_file_contents)
-    click.echo(f"mbed_config.cmake has been generated and written to '{str(output_directory.resolve())}'")
+    output_path = generate_config(mbed_target, toolchain, program)
+    click.echo(f"mbed_config.cmake has been generated and written to '{str(output_path.resolve())}'")

--- a/src/mbed_tools/cli/main.py
+++ b/src/mbed_tools/cli/main.py
@@ -16,7 +16,7 @@ from mbed_tools.lib.logging import set_log_level, MbedToolsHandler
 from mbed_tools.cli.configure import configure
 from mbed_tools.cli.list_connected_devices import list_connected_devices
 from mbed_tools.cli.project_management import init, clone, checkout, libs
-
+from mbed_tools.cli.build import build
 
 CONTEXT_SETTINGS = dict(help_option_names=["-h", "--help"])
 LOGGER = logging.getLogger(__name__)
@@ -77,3 +77,4 @@ cli.add_command(init, "init")
 cli.add_command(checkout, "checkout")
 cli.add_command(clone, "clone")
 cli.add_command(libs, "libs")
+cli.add_command(build, "build")

--- a/src/mbed_tools/project/_internal/project_data.py
+++ b/src/mbed_tools/project/_internal/project_data.py
@@ -20,6 +20,7 @@ logger = logging.getLogger(__name__)
 
 # Mbed program file names and constants.
 APP_CONFIG_FILE_NAME = "mbed_app.json"
+CMAKE_CONFIG_FILE_PATH = Path(".mbedbuild", "mbed_config.cmake")
 CMAKELISTS_FILE_NAME = "CMakeLists.txt"
 MAIN_CPP_FILE_NAME = "main.cpp"
 MBED_OS_REFERENCE_FILE_NAME = "mbed-os.lib"
@@ -48,11 +49,13 @@ class MbedProgramFiles:
         app_config_file: Path to mbed_app.json file. This can be `None` if the program doesn't set any custom config.
         mbed_os_ref: Library reference file for MbedOS. All programs require this file.
         cmakelists_file: A top-level CMakeLists.txt containing build definitions for the application.
+        cmake_config_file: Path to the CMake configuration script.
     """
 
     app_config_file: Optional[Path]
     mbed_os_ref: Path
     cmakelists_file: Path
+    cmake_config_file: Optional[Path]
 
     @classmethod
     def from_new(cls, root_path: Path) -> "MbedProgramFiles":
@@ -71,6 +74,7 @@ class MbedProgramFiles:
         cmakelists_file = root_path / CMAKELISTS_FILE_NAME
         main_cpp = root_path / MAIN_CPP_FILE_NAME
         gitignore = root_path / ".gitignore"
+        cmake_config = root_path / CMAKE_CONFIG_FILE_PATH
 
         if mbed_os_ref.exists():
             raise ValueError(f"Program already exists at path {root_path}.")
@@ -80,7 +84,12 @@ class MbedProgramFiles:
         render_cmakelists_template(cmakelists_file, root_path.stem)
         render_main_cpp_template(main_cpp)
         render_gitignore_template(gitignore)
-        return cls(app_config_file=app_config, mbed_os_ref=mbed_os_ref, cmakelists_file=cmakelists_file)
+        return cls(
+            app_config_file=app_config,
+            mbed_os_ref=mbed_os_ref,
+            cmakelists_file=cmakelists_file,
+            cmake_config_file=cmake_config,
+        )
 
     @classmethod
     def from_existing(cls, root_path: Path) -> "MbedProgramFiles":
@@ -102,7 +111,12 @@ class MbedProgramFiles:
             logger.warning("No CMakeLists.txt found in the program root. Creating it...")
             render_cmakelists_template(cmakelists_file, root_path.stem)
 
-        return cls(app_config_file=app_config, mbed_os_ref=mbed_os_file, cmakelists_file=cmakelists_file)
+        return cls(
+            app_config_file=app_config,
+            mbed_os_ref=mbed_os_file,
+            cmakelists_file=cmakelists_file,
+            cmake_config_file=root_path / CMAKE_CONFIG_FILE_PATH,
+        )
 
 
 @dataclass

--- a/src/mbed_tools/project/_internal/project_data.py
+++ b/src/mbed_tools/project/_internal/project_data.py
@@ -21,6 +21,7 @@ logger = logging.getLogger(__name__)
 # Mbed program file names and constants.
 APP_CONFIG_FILE_NAME = "mbed_app.json"
 CMAKE_CONFIG_FILE_PATH = Path(".mbedbuild", "mbed_config.cmake")
+CMAKE_BUILD_DIR = "cmake_build"
 CMAKELISTS_FILE_NAME = "CMakeLists.txt"
 MAIN_CPP_FILE_NAME = "main.cpp"
 MBED_OS_REFERENCE_FILE_NAME = "mbed-os.lib"
@@ -50,12 +51,14 @@ class MbedProgramFiles:
         mbed_os_ref: Library reference file for MbedOS. All programs require this file.
         cmakelists_file: A top-level CMakeLists.txt containing build definitions for the application.
         cmake_config_file: Path to the CMake configuration script.
+        cmake_build_dir: The CMake build tree.
     """
 
     app_config_file: Optional[Path]
     mbed_os_ref: Path
     cmakelists_file: Path
-    cmake_config_file: Optional[Path]
+    cmake_config_file: Path
+    cmake_build_dir: Path
 
     @classmethod
     def from_new(cls, root_path: Path) -> "MbedProgramFiles":
@@ -75,6 +78,7 @@ class MbedProgramFiles:
         main_cpp = root_path / MAIN_CPP_FILE_NAME
         gitignore = root_path / ".gitignore"
         cmake_config = root_path / CMAKE_CONFIG_FILE_PATH
+        cmake_build_dir = root_path / CMAKE_BUILD_DIR
 
         if mbed_os_ref.exists():
             raise ValueError(f"Program already exists at path {root_path}.")
@@ -89,6 +93,7 @@ class MbedProgramFiles:
             mbed_os_ref=mbed_os_ref,
             cmakelists_file=cmakelists_file,
             cmake_config_file=cmake_config,
+            cmake_build_dir=cmake_build_dir,
         )
 
     @classmethod
@@ -116,6 +121,7 @@ class MbedProgramFiles:
             mbed_os_ref=mbed_os_file,
             cmakelists_file=cmakelists_file,
             cmake_config_file=root_path / CMAKE_CONFIG_FILE_PATH,
+            cmake_build_dir=root_path / CMAKE_BUILD_DIR,
         )
 
 

--- a/tests/build/test_build.py
+++ b/tests/build/test_build.py
@@ -1,0 +1,46 @@
+#
+# Copyright (C) 2020 Arm Mbed. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+import pathlib
+
+from tempfile import TemporaryDirectory
+from unittest import TestCase, mock
+
+from mbed_tools.build.build import build_project, generate_build_system
+from mbed_tools.build.exceptions import MbedBuildError
+
+
+class TestBuildProject(TestCase):
+    @mock.patch("mbed_tools.build.build._cmake_wrapper")
+    def test_invokes_cmake_with_correct_args(self, cmake_wrapper):
+        build_project(build_dir="cmake_build", target="install")
+
+        cmake_wrapper.assert_called_once_with("--build", "cmake_build", "--target", "install")
+
+    @mock.patch("mbed_tools.build.build._cmake_wrapper")
+    def test_invokes_cmake_with_correct_args_if_no_target_passed(self, cmake_wrapper):
+        build_project(build_dir="cmake_build")
+
+        cmake_wrapper.assert_called_once_with("--build", "cmake_build")
+
+    def test_raises_build_error_if_build_dir_doesnt_exist(self):
+        with TemporaryDirectory() as tmp_dir:
+            nonexistent_build_dir = pathlib.Path(tmp_dir, "cmake_build")
+
+            with self.assertRaises(MbedBuildError):
+                build_project(nonexistent_build_dir)
+
+
+@mock.patch("mbed_tools.build.build._cmake_wrapper")
+class TestConfigureProject(TestCase):
+    def test_invokes_cmake_with_correct_args(self, cmake_wrapper):
+        source_dir = "source_dir"
+        build_dir = "cmake_build"
+        profile = "debug"
+
+        generate_build_system(source_dir, build_dir, profile)
+
+        cmake_wrapper.assert_called_once_with(
+            "-S", source_dir, "-B", build_dir, "-GNinja", f"-DCMAKE_BUILD_TYPE={profile}"
+        )

--- a/tests/build/test_generate_config.py
+++ b/tests/build/test_generate_config.py
@@ -1,0 +1,32 @@
+#
+# Copyright (C) 2020 Arm Mbed. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+from unittest import TestCase, mock
+
+from mbed_tools.build import generate_config
+
+
+class TestGenerateConfig(TestCase):
+    @mock.patch("mbed_tools.build.config.MbedProgram")
+    @mock.patch("mbed_tools.build.config.get_target_by_name")
+    @mock.patch("mbed_tools.build.config.generate_mbed_config_cmake_file")
+    @mock.patch("mbed_tools.build.config.assemble_config")
+    @mock.patch("mbed_tools.build.config.write_file")
+    def test_collaborators_called_with_corrrect_arguments(
+        self, write_file, assemble_config, gen_config_cmake, get_target_by_name, mbed_program
+    ):
+        program = mbed_program.from_existing()
+
+        generate_config("K64F", "GCC_ARM", program)
+
+        get_target_by_name.assert_called_once_with("K64F", program.mbed_os.targets_json_file)
+        assemble_config.assert_called_once_with(
+            get_target_by_name.return_value, program.root, program.files.app_config_file,
+        )
+        gen_config_cmake.assert_called_once_with(
+            "K64F", get_target_by_name.return_value, assemble_config.return_value, "GCC_ARM"
+        )
+        write_file.assert_called_once_with(
+            program.files.cmake_config_file.parent, program.files.cmake_config_file.name, gen_config_cmake.return_value,
+        )

--- a/tests/cli/test_build.py
+++ b/tests/cli/test_build.py
@@ -1,0 +1,130 @@
+#
+# Copyright (C) 2020 Arm Mbed. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+import contextlib
+import os
+import pathlib
+
+from tempfile import TemporaryDirectory
+from unittest import TestCase, mock
+
+from click.testing import CliRunner
+
+from mbed_tools.cli.build import build
+from mbed_tools.project._internal.project_data import CMAKE_CONFIG_FILE_PATH, CMAKE_BUILD_DIR
+
+
+@contextlib.contextmanager
+def mock_project_directory(program, mbed_config_exists=False, build_tree_exists=False):
+    with TemporaryDirectory() as tmp_dir:
+        root = pathlib.Path(tmp_dir, "test-project")
+        root.mkdir()
+        program.root = root
+        program.files.cmake_build_dir = root / CMAKE_BUILD_DIR
+        program.files.cmake_config_file = root / CMAKE_CONFIG_FILE_PATH
+        if mbed_config_exists:
+            program.files.cmake_config_file.parent.mkdir(exist_ok=True)
+            program.files.cmake_config_file.touch(exist_ok=True)
+
+        if build_tree_exists:
+            program.files.cmake_build_dir.mkdir(exist_ok=True)
+
+        yield
+
+
+@mock.patch("mbed_tools.cli.build.generate_build_system")
+@mock.patch("mbed_tools.cli.build.build_project")
+@mock.patch("mbed_tools.cli.build.MbedProgram")
+@mock.patch("mbed_tools.cli.build.generate_config")
+class TestBuildCommand(TestCase):
+    def test_searches_for_mbed_program_at_default_project_path(
+        self, generate_config, mbed_program, build_project, generate_build_system
+    ):
+        runner = CliRunner()
+        runner.invoke(build)
+
+        mbed_program.from_existing.assert_called_once_with(pathlib.Path(os.getcwd()))
+
+    def test_searches_for_mbed_program_at_user_defined_project_root(
+        self, generate_config, mbed_program, build_project, generate_build_system
+    ):
+        project_path = "my-blinky"
+
+        runner = CliRunner()
+        runner.invoke(build, ["-p", project_path])
+
+        mbed_program.from_existing.assert_called_once_with(pathlib.Path(project_path))
+
+    def test_calls_generate_build_system_if_build_tree_nonexistent(
+        self, generate_config, mbed_program, build_project, generate_build_system
+    ):
+        program = mbed_program.from_existing()
+        with mock_project_directory(program, mbed_config_exists=True, build_tree_exists=False):
+            runner = CliRunner()
+            runner.invoke(build)
+
+            generate_build_system.assert_called_once_with(program.root, program.files.cmake_build_dir, "develop")
+
+    def test_generate_build_system_not_called_if_build_tree_exists(
+        self, generate_config, mbed_program, build_project, generate_build_system
+    ):
+        program = mbed_program.from_existing()
+        with mock_project_directory(program, mbed_config_exists=True, build_tree_exists=True):
+            runner = CliRunner()
+            runner.invoke(build)
+
+            generate_build_system.assert_not_called()
+
+    def test_generate_config_called_if_config_script_nonexistent(
+        self, generate_config, mbed_program, build_project, generate_build_system
+    ):
+        program = mbed_program.from_existing()
+        with mock_project_directory(program, mbed_config_exists=False):
+            target = "k64f"
+            toolchain = "gcc_arm"
+
+            runner = CliRunner()
+            runner.invoke(build, ["-t", toolchain, "-m", target])
+
+            generate_config.assert_called_once_with(target.upper(), toolchain.upper(), program)
+
+    def test_raises_if_gen_config_toolchain_not_passed_when_required(
+        self, generate_config, mbed_program, build_project, generate_build_system
+    ):
+        program = mbed_program.from_existing()
+        with mock_project_directory(program, mbed_config_exists=False):
+            target = "k64f"
+
+            runner = CliRunner()
+            result = runner.invoke(build, ["-m", target])
+
+            self.assertIsNotNone(result.exception)
+            self.assertRegex(result.output, "--toolchain")
+
+    def test_raises_if_gen_config_target_not_passed_when_required(
+        self, generate_config, mbed_program, build_project, generate_build_system
+    ):
+        program = mbed_program.from_existing()
+        with mock_project_directory(program, mbed_config_exists=False):
+            toolchain = "gcc_arm"
+
+            runner = CliRunner()
+            result = runner.invoke(build, ["-t", toolchain])
+
+            self.assertIsNotNone(result.exception)
+            self.assertRegex(result.output, "--mbed-target")
+
+    def test_clean_forces_regeneration_of_config_and_build_system(
+        self, generate_config, mbed_program, build_project, generate_build_system
+    ):
+        program = mbed_program.from_existing()
+        with mock_project_directory(program, mbed_config_exists=True, build_tree_exists=True):
+            toolchain = "gcc_arm"
+            target = "k64f"
+
+            runner = CliRunner()
+            runner.invoke(build, ["-t", toolchain, "-m", target, "--clean"])
+
+            generate_config.assert_called_once_with(target.upper(), toolchain.upper(), program)
+            generate_build_system.assert_called_once_with(program.root, program.files.cmake_build_dir, "develop")

--- a/tests/cli/test_configure.py
+++ b/tests/cli/test_configure.py
@@ -2,8 +2,6 @@
 # Copyright (C) 2020 Arm Mbed. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
-import pathlib
-
 from unittest import TestCase, mock
 
 from click.testing import CliRunner
@@ -12,30 +10,9 @@ from mbed_tools.cli.configure import configure
 
 
 class TestConfigureCommand(TestCase):
+    @mock.patch("mbed_tools.cli.configure.generate_config")
     @mock.patch("mbed_tools.cli.configure.MbedProgram")
-    @mock.patch("mbed_tools.cli.configure.get_target_by_name")
-    @mock.patch("mbed_tools.cli.configure.generate_mbed_config_cmake_file")
-    @mock.patch("mbed_tools.cli.configure.assemble_config")
-    @mock.patch("mbed_tools.cli.configure.write_file")
-    def test_collaborators_called_with_corrrect_arguments(
-        self, write_file, assemble_config, gen_config_cmake, get_target_by_name, mbed_program
-    ):
-        CliRunner().invoke(configure, ["-m", "k64f", "-t", "GCC_ARM"])
+    def test_generate_config_called_with_correct_arguments(self, program, generate_config):
+        CliRunner().invoke(configure, ["-m", "k64f", "-t", "gcc_arm"])
 
-        mbed_program.from_existing.assert_called_once_with(pathlib.Path("."))
-        get_target_by_name.assert_called_once_with(
-            "K64F", mbed_program.from_existing.return_value.mbed_os.targets_json_file
-        )
-        assemble_config.assert_called_once_with(
-            get_target_by_name.return_value,
-            mbed_program.from_existing.return_value.root,
-            mbed_program.from_existing.return_value.files.app_config_file,
-        )
-        gen_config_cmake.assert_called_once_with(
-            "K64F", get_target_by_name.return_value, assemble_config.return_value, "GCC_ARM"
-        )
-        write_file.assert_called_once_with(
-            mbed_program.from_existing.return_value.root / ".mbedbuild",
-            "mbed_config.cmake",
-            gen_config_cmake.return_value,
-        )
+        generate_config.assert_called_once_with("K64F", "GCC_ARM", program.from_existing())

--- a/travis-ci/functions.sh
+++ b/travis-ci/functions.sh
@@ -62,14 +62,6 @@ _setup_build_env()
   pip install --upgrade cmake
 }
 
-_config_and_build()
-{
-    mbedtools configure -t GCC_ARM -m ${TARGET_NAME}
-
-    cmake -S . -B build -GNinja -DCMAKE_BUILD_TYPE=${PROFILE}
-    cmake --build build
-}
-
 _clone_dependencies()
 {
   # We use manual clone, with depth and single branch = the fastest

--- a/travis-ci/functions.sh
+++ b/travis-ci/functions.sh
@@ -1,20 +1,8 @@
 #!/bin/bash -euf
-#
-# Copyright (c) 2020 Arm Limited. All rights reserved.
-#
-# SPDX-License-Identifier: Apache-2.0
-#
-# Licensed under the Apache License, Version 2.0 (the License); you may
-# not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an AS IS BASIS, WITHOUT
-# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+##
+## Copyright (C) 2020 Arm Mbed. All rights reserved.
+## SPDX-License-Identifier: Apache-2.0
+##
 
 set -o pipefail
 


### PR DESCRIPTION
### Description

Add build command porcelain.

### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [x]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
