### PR TITLE
configure: Don't emit _PRESENT macros

### DIFF
--- a/news/20200929160957.misc
+++ b/news/20200929160957.misc
@@ -1,0 +1,1 @@
+Don't emit _PRESENT macros. Depend on Mbed OS to define these from CMake.

--- a/src/mbed_tools/build/_internal/config/config.py
+++ b/src/mbed_tools/build/_internal/config/config.py
@@ -104,6 +104,14 @@ class Config:
         config = Config()
         for source in sources:
             for key, value in source.config.items():
+                # If the config item is about a certain component or feature
+                # being present, avoid adding it to the mbed_config.cmake
+                # configuration file. Instead, applications should depend on
+                # the feature or component with target_link_libraries() and the
+                # component's CMake flle (in the Mbed OS repo) will create
+                # any necessary macros or definitions.
+                if key.endswith(".present"):
+                    continue
                 _create_config_option(config, key, value, source)
             for key, value in source.overrides.items():
                 if key in IGNORED_OVERRIDE_KEYS_IN_SOURCE:


### PR DESCRIPTION
### Description

Do not put macros like MBED_CONF_FILESYSTEM_PRESENT or
MBED_CONF_EVENTS_PRESENT into the applicaiton's generated
mbed_config.cmake file. We will depend on Mbed OS CMake files for each
of these components to define the _PRESENT macro in a
target_compile_definitions() block for the e.g. filesystem or events
CMake targets.

This should be merged immediately before [the Mbed OS companion PR](https://github.com/ARMmbed/mbed-os/pull/13732) is ready. Then, we should merge this PR, do a tools release, merge Mbed OS example PRs, and merge the Mbed OS PR. Without Mbed OS having updated CMake files, these tool changes will break some builds.

### Test Coverage

- [ ]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [X]  Additional tests are not required for this change (e.g. documentation update).
