### PR TITLE
Use `towncrier.check` instead of `assert-news`

### DIFF
--- a/azure-pipelines/build-release.yml
+++ b/azure-pipelines/build-release.yml
@@ -116,12 +116,10 @@ stages:
             inputs:
               versionSpec: '3.7'
 
-          - template: steps/determine-current-branch.yml
-
           - template: steps/install-development-dependencies.yml
 
           - script: |
-              assert-news -b $(current_branch)
+              tox -e checknews
             displayName: 'Run check'
 
   - stage: DocBuild

--- a/azure-pipelines/steps/install-development-dependencies.yml
+++ b/azure-pipelines/steps/install-development-dependencies.yml
@@ -12,6 +12,7 @@ steps:
       python -m pipenv lock --dev-only -r --pre > dev-requirements.txt
       pip install -r dev-requirements.txt
       pip install pytest-azurepipelines
+      pip install tox
       pip install .
       pip list
     displayName: 'Install development dependencies'

--- a/news/20201001170005.feature
+++ b/news/20201001170005.feature
@@ -1,0 +1,1 @@
+Replace assert-news with towncrier.check

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = dev,linting,py36,py37,py38
+envlist = dev,linting,checknews,py36,py37,py38
 minversion = 3.3.0
 # Activate isolated build environment. tox will use a virtual environment
 # to build a source distribution from the source tree.
@@ -23,3 +23,9 @@ commands =
 deps =
     -rrequirements-test.txt
     -rrequirements-dev.txt
+
+[testenv:checknews]
+skip_install = True
+deps =
+    towncrier
+commands = python -m towncrier.check


### PR DESCRIPTION
### Description

`assert-news` will be removed from `mbed-tools-ci-scripts` to reduce maintenance overhead of custom scripts. `towncrier` now supports checking news files.



### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [x]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
