### PR TITLE
Build command improvements

### DIFF
--- a/news/20201012141322.feature
+++ b/news/20201012141322.feature
@@ -1,0 +1,1 @@
+Always regenerate build configuration when target and toolchain arguments are passed to the build subcommand.

--- a/src/mbed_tools/build/build.py
+++ b/src/mbed_tools/build/build.py
@@ -3,12 +3,16 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 """Configure and build a CMake project."""
+import logging
 import pathlib
 import subprocess
 
 from typing import Optional
 
 from mbed_tools.build.exceptions import MbedBuildError
+
+
+logger = logging.getLogger(__name__)
 
 
 def build_project(build_dir: pathlib.Path, target: Optional[str] = None) -> None:
@@ -35,6 +39,7 @@ def generate_build_system(source_dir: pathlib.Path, build_dir: pathlib.Path, pro
 
 def _cmake_wrapper(*cmake_args: str) -> None:
     try:
+        logger.debug("Running CMake with args: %s", cmake_args)
         subprocess.run(["cmake", *cmake_args], check=True)
     except subprocess.CalledProcessError:
         raise MbedBuildError("CMake invocation failed!")

--- a/src/mbed_tools/cli/build.py
+++ b/src/mbed_tools/cli/build.py
@@ -21,14 +21,13 @@ from mbed_tools.project import MbedProgram
 )
 @click.option("-m", "--mbed-target", help="A build target for an Mbed-enabled device, e.g. K64F.")
 @click.option("-b", "--build-type", default="develop", help="The build type (release, develop or debug).")
-@click.option("-c", "--clean", is_flag=True, default=False, help="Perform a 'clean' build.")
 @click.option(
     "-p",
     "--program-path",
     default=os.getcwd(),
     help="Path to local Mbed program. By default it is the current working directory.",
 )
-def build(program_path: str, build_type: str, toolchain: str = "", mbed_target: str = "", clean: bool = False) -> None:
+def build(program_path: str, build_type: str, toolchain: str = "", mbed_target: str = "") -> None:
     """Configure and build an Mbed project using CMake and Ninja.
 
     If the project has already been configured and contains '.mbedbuild/mbed_config.cmake', this command will skip the
@@ -42,22 +41,19 @@ def build(program_path: str, build_type: str, toolchain: str = "", mbed_target: 
        build_type: The Mbed build profile (debug, develop or release).
        toolchain: The toolchain to use for the build.
        mbed_target: The name of the Mbed target to build for.
-       clean: Force regeneration of config and build system before building.
     """
     program = MbedProgram.from_existing(pathlib.Path(program_path))
     mbed_config_file = program.files.cmake_config_file
-    if not mbed_config_file.exists() or clean:
-        click.echo("Generating Mbed config...")
-        if not toolchain:
-            raise click.UsageError("--toolchain argument is required when generating Mbed config!")
-
-        if not mbed_target:
-            raise click.UsageError("--mbed-target argument is required when generating Mbed config!")
-
-        generate_config(mbed_target.upper(), toolchain, program)
-
     build_tree = program.files.cmake_build_dir
-    if not build_tree.exists() or clean:
+    if any([not mbed_config_file.exists(), not build_tree.exists(), mbed_target, toolchain]):
+        click.echo("Configuring project and generating build system...")
+        _validate_target_and_toolchain_args(mbed_target, toolchain)
+        generate_config(mbed_target.upper(), toolchain, program)
         generate_build_system(program.root, build_tree, build_type)
-
+    click.echo("Building Mbed project...")
     build_project(build_tree)
+
+
+def _validate_target_and_toolchain_args(target: str, toolchain: str) -> None:
+    if not all([toolchain, target]):
+        raise click.UsageError("--toolchain and --mbed-target arguments are required when generating Mbed config!")

--- a/tests/cli/test_build.py
+++ b/tests/cli/test_build.py
@@ -62,7 +62,7 @@ class TestBuildCommand(TestCase):
         program = mbed_program.from_existing()
         with mock_project_directory(program, mbed_config_exists=True, build_tree_exists=False):
             runner = CliRunner()
-            runner.invoke(build)
+            runner.invoke(build, ["-m", "k64f", "-t", "gcc_arm"])
 
             generate_build_system.assert_called_once_with(program.root, program.files.cmake_build_dir, "develop")
 
@@ -115,7 +115,7 @@ class TestBuildCommand(TestCase):
             self.assertIsNotNone(result.exception)
             self.assertRegex(result.output, "--mbed-target")
 
-    def test_clean_forces_regeneration_of_config_and_build_system(
+    def test_build_system_regenerated_when_target_and_toolchain_passed(
         self, generate_config, mbed_program, build_project, generate_build_system
     ):
         program = mbed_program.from_existing()
@@ -124,7 +124,7 @@ class TestBuildCommand(TestCase):
             target = "k64f"
 
             runner = CliRunner()
-            runner.invoke(build, ["-t", toolchain, "-m", target, "--clean"])
+            runner.invoke(build, ["-t", toolchain, "-m", target])
 
             generate_config.assert_called_once_with(target.upper(), toolchain.upper(), program)
             generate_build_system.assert_called_once_with(program.root, program.files.cmake_build_dir, "develop")

--- a/tests/cli/test_build.py
+++ b/tests/cli/test_build.py
@@ -128,3 +128,18 @@ class TestBuildCommand(TestCase):
 
             generate_config.assert_called_once_with(target.upper(), toolchain.upper(), program)
             generate_build_system.assert_called_once_with(program.root, program.files.cmake_build_dir, "develop")
+
+    def test_build_folder_removed_when_clean_flag_passed(
+        self, generate_config, mbed_program, build_project, generate_build_system
+    ):
+        program = mbed_program.from_existing()
+        with mock_project_directory(program, mbed_config_exists=True, build_tree_exists=True):
+            toolchain = "gcc_arm"
+            target = "k64f"
+
+            runner = CliRunner()
+            runner.invoke(build, ["-t", toolchain, "-m", target, "-c"])
+
+            generate_config.assert_called_once_with(target.upper(), toolchain.upper(), program)
+            generate_build_system.assert_called_once_with(program.root, program.files.cmake_build_dir, "develop")
+            self.assertFalse(program.files.cmake_build_dir.exists())


### PR DESCRIPTION
### Description

So users can easily build for another target, always reconfigure the
project when --mbed-target and --toolchain flags are passed to the build
subcommand.

--clean will now remove the CMake build tree and force a clean rebuild.


### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [x]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
