### PR TITLE
docs: Add `build` and `libs` command option

### DIFF
--- a/docs/howto/mbed-tools-howto.md
+++ b/docs/howto/mbed-tools-howto.md
@@ -227,6 +227,14 @@ We can use a single command which will configure (set up your target and toolcha
     mbed-tools build
     ```
 
+## List library dependencies of an application
+
+All library dependencies can be listed with their URL and Git references as follows:
+
+```
+mbed-tools libs
+```
+
 ## Logging
 
 To specify the log level, use the verbose logging option (`-v`) before the first argument.

--- a/docs/howto/mbed-tools-howto.md
+++ b/docs/howto/mbed-tools-howto.md
@@ -134,8 +134,8 @@ VARIABLE1=<value>
 VARIABLE2=<value>
 ```
 
-Environment variables take precedence, meaning the values set in the file will be overriden	
-by any values previously set in your environment.	
+Environment variables take precedence, meaning the values set in the file will be overriden
+by any values previously set in your environment.
 
 **Warning**:
 Do not upload `.env` files containing private tokens to version control.
@@ -201,6 +201,31 @@ Use CMake to build your application:
     This generates two files in the build output directory (`cmake_build` in this example): HEX and BIN.
 
 1. Drag and drop the generated file to your board.
+
+
+## Mbed OS Configuration and building the project
+
+We can use a single command which will configure (set up your target and toolchain) and build the project.
+
+    1. To build and configure:
+
+    ```
+    mbed-tools build -m <target> -t <toolchain>
+    ```
+    - -t: The toolchain you are using to build your app
+    - -m: A build target for an Mbed-enabled device
+
+    Example for FRDM-K64F and GCC:
+
+    ```
+    mbed-tools build -m K64F -t GCC_ARM
+    ```
+
+    1. To perform an iterative build on previously configured target:
+
+    ```
+    mbed-tools build
+    ```
 
 ## Logging
 

--- a/news/202010131300.doc
+++ b/news/202010131300.doc
@@ -1,0 +1,1 @@
+Document build command

--- a/news/202010211355.doc
+++ b/news/202010211355.doc
@@ -1,0 +1,1 @@
+Document libs command


### PR DESCRIPTION
### Description

<!--
Please add any detail or context that would be useful to a reviewer.
-->

 Build command can be used to configure and build the target

Merge after https://github.com/ARMmbed/mbed-tools/pull/86

### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [x]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
