### PR TITLE
config: Test Config.from_sources ignores 'present' macros

### DIFF
--- a/news/20201016135546.misc
+++ b/news/20201016135546.misc
@@ -1,0 +1,1 @@
+Add unit test for filtering of 'present' macros

--- a/tests/build/_internal/config/test_config.py
+++ b/tests/build/_internal/config/test_config.py
@@ -60,6 +60,13 @@ class TestConfigFromSources(TestCase):
                 source_b = SourceFactory(overrides={key: "boom?"})
                 Config.from_sources([source_a, source_b])
 
+    def test_ignores_present_option(self):
+        source = SourceFactory(config={"mbed_component.present": {"help": "Mbed Component", "value": True}})
+
+        config = Config.from_sources([source])
+
+        self.assertFalse(config.options)
+
 
 class TestOptionBuild(TestCase):
     def test_builds_option_from_config_data(self):


### PR DESCRIPTION
### Description

No test case was added for https://github.com/ARMmbed/mbed-tools/commit/231dbc443bc14b2932f68fda23a6e5fedb94a481 this is causing codecov to fail.

### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [x]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
