### PR TITLE
fix: https to ssh redirection on local host machine

### DIFF
--- a/news/66.bugfix
+++ b/news/66.bugfix
@@ -1,0 +1,1 @@
+Fix https to ssh redirection

--- a/src/mbed_tools/project/_internal/libraries.py
+++ b/src/mbed_tools/project/_internal/libraries.py
@@ -42,6 +42,10 @@ class MbedLibReference:
         """
         raw_ref = self.reference_file.read_text().strip()
         url, sep, ref = raw_ref.partition("#")
+
+        if url.endswith("/"):
+            url = url[:-1]
+
         return git_utils.GitReference(repo_url=url, ref=ref)
 
 

--- a/tests/project/_internal/test_project_data.py
+++ b/tests/project/_internal/test_project_data.py
@@ -108,13 +108,15 @@ class TestMbedLibReference(TestCase):
         root = pathlib.Path(fs, "foo")
         url = "https://github.com/mylibrepo"
         ref = "latest"
-        full_ref = f"{url}#{ref}"
-        lib = make_mbed_lib_reference(root, ref_url=full_ref)
+        references = [f"{url}#{ref}", f"{url}/#{ref}"]
 
-        reference = lib.get_git_reference()
+        for full_ref in references:
+            lib = make_mbed_lib_reference(root, ref_url=full_ref)
 
-        self.assertEqual(reference.repo_url, url)
-        self.assertEqual(reference.ref, ref)
+            reference = lib.get_git_reference()
+
+            self.assertEqual(reference.repo_url, url)
+            self.assertEqual(reference.ref, ref)
 
 
 class TestMbedOS(TestCase):


### PR DESCRIPTION


### Description

<!--
Please add any detail or context that would be useful to a reviewer.
-->

It is been observed that `mbedtools clone` command fails if the host
has a redirection in their git config --global.

This is mainly because of url contains `\` which git is unhappy about

Fixes #66

### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [x]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
