### PR TITLE
Fix mbedtools clone for examples containing multiple programs

### DIFF
--- a/news/62.bugfix
+++ b/news/62.bugfix
@@ -1,0 +1,1 @@
+Do not check for mbed-os.lib in MbedProgram::from_url as it was making clone fail on examples containing multiple programs.

--- a/src/mbed_tools/project/_internal/libraries.py
+++ b/src/mbed_tools/project/_internal/libraries.py
@@ -50,7 +50,7 @@ class LibraryReferences:
     """Manages library references in an MbedProgram."""
 
     root: Path
-    ignore_paths: List[Path]
+    ignore_paths: List[str]
 
     def resolve(self) -> None:
         """Recursively clone all dependencies defined in .lib files."""
@@ -106,4 +106,4 @@ class LibraryReferences:
 
     def _in_ignore_path(self, lib_reference_path: Path) -> bool:
         """Check if a library reference is in a path we want to ignore."""
-        return any(p in lib_reference_path.parents for p in self.ignore_paths)
+        return any(p in lib_reference_path.parts for p in self.ignore_paths)

--- a/src/mbed_tools/project/_internal/project_data.py
+++ b/src/mbed_tools/project/_internal/project_data.py
@@ -113,8 +113,7 @@ class MbedProgramFiles:
 
         cmakelists_file = root_path / CMAKELISTS_FILE_NAME
         if not cmakelists_file.exists():
-            logger.warning("No CMakeLists.txt found in the program root. Creating it...")
-            render_cmakelists_template(cmakelists_file, root_path.stem)
+            logger.warning("No CMakeLists.txt found in the program root.")
 
         return cls(
             app_config_file=app_config,

--- a/src/mbed_tools/project/mbed_program.py
+++ b/src/mbed_tools/project/mbed_program.py
@@ -26,7 +26,6 @@ class MbedProgram:
     """Represents an Mbed program.
 
     An `MbedProgram` consists of:
-        * A git repository
         * A copy of, or reference to, `MbedOS`
         * A set of `MbedProgramFiles`
         * A collection of references to external libraries, defined in .lib files located in the program source tree

--- a/src/mbed_tools/project/mbed_program.py
+++ b/src/mbed_tools/project/mbed_program.py
@@ -44,7 +44,7 @@ class MbedProgram:
         self.lib_references = LibraryReferences(root=self.root, ignore_paths=[self.mbed_os.root.name])
 
     @classmethod
-    def from_url(cls, url: str, dst_path: Path, check_mbed_os: bool = True) -> "MbedProgram":
+    def from_url(cls, url: str, dst_path: Path) -> "MbedProgram":
         """Fetch an Mbed program from a remote URL.
 
         Args:
@@ -55,7 +55,7 @@ class MbedProgram:
         git_utils.clone(url, dst_path)
         program_files = MbedProgramFiles.from_existing(dst_path)
         try:
-            mbed_os = MbedOS.from_existing(dst_path / MBED_OS_DIR_NAME, check_mbed_os)
+            mbed_os = MbedOS.from_existing(dst_path / MBED_OS_DIR_NAME, False)
         except ValueError as mbed_err:
             raise MbedOSNotFound(f"{mbed_err}")
 

--- a/src/mbed_tools/project/mbed_program.py
+++ b/src/mbed_tools/project/mbed_program.py
@@ -41,7 +41,7 @@ class MbedProgram:
         self.files = program_files
         self.root = self.files.mbed_os_ref.parent
         self.mbed_os = mbed_os
-        self.lib_references = LibraryReferences(root=self.root, ignore_paths=[self.mbed_os.root])
+        self.lib_references = LibraryReferences(root=self.root, ignore_paths=[self.mbed_os.root.name])
 
     @classmethod
     def from_url(cls, url: str, dst_path: Path, check_mbed_os: bool = True) -> "MbedProgram":
@@ -50,27 +50,10 @@ class MbedProgram:
         Args:
             url: URL of the remote program repository.
             dst_path: Destination path for the cloned program.
-
-        Raises:
-            ExistingProgram: `dst_path` already contains an Mbed program.
         """
-        if _tree_contains_program(dst_path):
-            raise ExistingProgram(
-                f"The destination path '{dst_path}' already contains an Mbed program. Please set the destination path "
-                "to an empty directory."
-            )
         logger.info(f"Cloning Mbed program from URL '{url}'.")
         git_utils.clone(url, dst_path)
-
         program_files = MbedProgramFiles.from_existing(dst_path)
-        if not program_files.mbed_os_ref.exists():
-            raise ProgramNotFound(
-                "This repository does not contain a valid Mbed program at the top level. "
-                "Cloned programs must contain an mbed-os.lib file containing the URL to the Mbed OS repository. It is "
-                "possible you have cloned a repository containing multiple mbed-programs. If this is the case, you "
-                "should cd to a directory containing a program before performing any other operations."
-            )
-
         try:
             mbed_os = MbedOS.from_existing(dst_path / MBED_OS_DIR_NAME, check_mbed_os)
         except ValueError as mbed_err:

--- a/src/mbed_tools/project/project.py
+++ b/src/mbed_tools/project/project.py
@@ -26,7 +26,7 @@ def clone_project(url: str, dst_path: Any = None, recursive: bool = False) -> No
     if not dst_path:
         dst_path = pathlib.Path(git_data["dst_path"])
 
-    program = MbedProgram.from_url(url, dst_path, check_mbed_os=False)
+    program = MbedProgram.from_url(url, dst_path)
     if recursive:
         program.resolve_libraries()
 

--- a/tests/project/_internal/test_libraries.py
+++ b/tests/project/_internal/test_libraries.py
@@ -18,7 +18,7 @@ class TestLibraryReferences(TestCase):
         lib = make_mbed_lib_reference(fs_root, ref_url="https://git")
         mock_clone.side_effect = lambda url, dst_dir: dst_dir.mkdir()
 
-        lib_refs = LibraryReferences(fs_root, ignore_paths=[fs_root / "mbed-os"])
+        lib_refs = LibraryReferences(fs_root, ignore_paths=["mbed-os"])
         lib_refs.resolve()
 
         mock_clone.assert_called_once_with(lib.get_git_reference().repo_url, lib.source_code_path)
@@ -40,7 +40,7 @@ class TestLibraryReferences(TestCase):
             lib2.source_code_path.mkdir(),
         )
 
-        lib_refs = LibraryReferences(fs_root, ignore_paths=[fs_root / "mbed-os"])
+        lib_refs = LibraryReferences(fs_root, ignore_paths=["mbed-os"])
         lib_refs.resolve()
 
         self.assertTrue(lib.is_resolved())
@@ -53,7 +53,7 @@ class TestLibraryReferences(TestCase):
         fs_root = pathlib.Path(fs, "foo")
         make_mbed_lib_reference(fs_root, ref_url="https://git", resolved=True)
 
-        lib_refs = LibraryReferences(fs_root, ignore_paths=[fs_root / "mbed-os"])
+        lib_refs = LibraryReferences(fs_root, ignore_paths=["mbed-os"])
         lib_refs.checkout(force=False)
 
         mock_checkout.assert_not_called()
@@ -65,7 +65,7 @@ class TestLibraryReferences(TestCase):
         fs_root = pathlib.Path(fs, "foo")
         lib = make_mbed_lib_reference(fs_root, ref_url="https://git#lajdhalk234", resolved=True)
 
-        lib_refs = LibraryReferences(fs_root, ignore_paths=[fs_root / "mbed-os"])
+        lib_refs = LibraryReferences(fs_root, ignore_paths=["mbed-os"])
         lib_refs.checkout(force=False)
 
         mock_checkout.assert_called_once_with(mock_init.return_value, lib.get_git_reference().ref, force=False)
@@ -78,7 +78,7 @@ class TestLibraryReferences(TestCase):
         make_mbed_lib_reference(fs_root, ref_url="https://git")
         mock_clone.side_effect = lambda url, dst_dir: dst_dir.mkdir()
 
-        lib_refs = LibraryReferences(fs_root, ignore_paths=[fs_root / "mbed-os"])
+        lib_refs = LibraryReferences(fs_root, ignore_paths=["mbed-os"])
         lib_refs.resolve()
 
         mock_checkout.assert_not_called()
@@ -91,7 +91,19 @@ class TestLibraryReferences(TestCase):
         lib = make_mbed_lib_reference(fs_root, ref_url="https://git#lajdhalk234")
         mock_clone.side_effect = lambda url, dst_dir: dst_dir.mkdir()
 
-        lib_refs = LibraryReferences(fs_root, ignore_paths=[fs_root / "mbed-os"])
+        lib_refs = LibraryReferences(fs_root, ignore_paths=["mbed-os"])
         lib_refs.resolve()
 
         mock_checkout.assert_called_once_with(None, lib.get_git_reference().ref)
+
+    @patchfs
+    @mock.patch("mbed_tools.project._internal.git_utils.checkout", autospec=True)
+    @mock.patch("mbed_tools.project._internal.git_utils.init", autospec=True)
+    def test_does_not_resolve_references_in_ignore_paths(self, mock_init, mock_checkout, mock_clone, fs):
+        fs_root = pathlib.Path(fs, "mbed-os")
+        make_mbed_lib_reference(fs_root, ref_url="https://git#lajdhalk234")
+
+        lib_refs = LibraryReferences(fs_root, ignore_paths=["mbed-os"])
+        lib_refs.resolve()
+
+        mock_clone.assert_not_called()

--- a/tests/project/_internal/test_mbed_program.py
+++ b/tests/project/_internal/test_mbed_program.py
@@ -61,22 +61,12 @@ class TestInitialiseProgram(TestCase):
         self.assertEqual(program.files, MbedProgramFiles.from_existing(program_root))
 
     @patchfs
-    @mock.patch("mbed_tools.project._internal.git_utils.clone", autospec=True)
-    def test_from_url_raises_if_check_mbed_os_is_true_and_mbed_os_dir_nonexistent(self, mock_clone, fs):
-        fs_root = pathlib.Path(fs, "foo")
-        url = "https://validrepo.com"
-        mock_clone.side_effect = lambda *args: make_mbed_program_files(fs_root)
-
-        with self.assertRaises(MbedOSNotFound):
-            MbedProgram.from_url(url, fs_root, check_mbed_os=True)
-
-    @patchfs
     @mock.patch("mbed_tools.project.mbed_program.git_utils.clone", autospec=True)
     def test_from_url_returns_valid_program(self, mock_clone, fs):
         fs_root = pathlib.Path(fs, "foo")
         url = "https://valid"
         mock_clone.side_effect = lambda *args: make_mbed_program_files(fs_root)
-        program = MbedProgram.from_url(url, fs_root, False)
+        program = MbedProgram.from_url(url, fs_root)
 
         self.assertEqual(program.files, MbedProgramFiles.from_existing(fs_root))
         mock_clone.assert_called_once_with(url, fs_root)

--- a/tests/project/_internal/test_project_data.py
+++ b/tests/project/_internal/test_project_data.py
@@ -10,7 +10,6 @@ from unittest import TestCase, mock
 from mbed_tools.project._internal.project_data import (
     MbedProgramFiles,
     MbedOS,
-    CMAKELISTS_FILE_NAME,
     MAIN_CPP_FILE_NAME,
 )
 from tests.project.factories import make_mbed_lib_reference, make_mbed_program_files, make_mbed_os_files, patchfs
@@ -64,28 +63,6 @@ class TestMbedProgramFiles(TestCase):
         self.assertTrue(program.app_config_file.exists())
         self.assertTrue(program.mbed_os_ref.exists())
         self.assertTrue(program.cmakelists_file.exists())
-
-    @patchfs
-    def test_from_existing_calls_render_cmakelists_template_with_program_name_if_file_nonexistent(self, fs):
-        with mock.patch("mbed_tools.project._internal.project_data.render_cmakelists_template") as render_cmake:
-            root = pathlib.Path(fs, "foo")
-            make_mbed_program_files(root)
-            render_cmake.return_value = "foo"
-
-            program_files = MbedProgramFiles.from_existing(root)
-
-            render_cmake.assert_called_with(program_files.cmakelists_file, root.stem)
-
-    @patchfs
-    def test_from_existing_skips_rendering_cmake_template_if_file_exists(self, fs):
-        with mock.patch("mbed_tools.project._internal.project_data.render_cmakelists_template") as render_cmake:
-            root = pathlib.Path(fs, "foo")
-            make_mbed_program_files(root)
-            (root / CMAKELISTS_FILE_NAME).touch()
-
-            MbedProgramFiles.from_existing(root)
-
-            render_cmake.assert_not_called()
 
 
 class TestMbedLibReference(TestCase):

--- a/tests/project/factories.py
+++ b/tests/project/factories.py
@@ -5,6 +5,11 @@
 from functools import wraps
 from tempfile import TemporaryDirectory
 from mbed_tools.project._internal.libraries import MbedLibReference
+from mbed_tools.project._internal.project_data import (
+    CMAKELISTS_FILE_NAME,
+    APP_CONFIG_FILE_NAME,
+    MBED_OS_REFERENCE_FILE_NAME,
+)
 
 
 def patchfs(func):
@@ -16,12 +21,13 @@ def patchfs(func):
     return wrapper
 
 
-def make_mbed_program_files(root, config_file_name="mbed_app.json"):
+def make_mbed_program_files(root, config_file_name=APP_CONFIG_FILE_NAME):
     if not root.exists():
         root.mkdir()
 
-    (root / "mbed-os.lib").touch()
+    (root / MBED_OS_REFERENCE_FILE_NAME).touch()
     (root / config_file_name).touch()
+    (root / CMAKELISTS_FILE_NAME).touch()
 
 
 def make_mbed_lib_reference(root, name="mylib.lib", resolved=False, ref_url=None):

--- a/tests/project/test_mbed_project.py
+++ b/tests/project/test_mbed_project.py
@@ -32,13 +32,13 @@ class TestCloneProject(TestCase):
         url = "https://git.com/gitorg/repo"
         clone_project(url, recursive=False)
 
-        mock_program.from_url.assert_called_once_with(url, pathlib.Path(url.rsplit("/", maxsplit=1)[-1]), False)
+        mock_program.from_url.assert_called_once_with(url, pathlib.Path(url.rsplit("/", maxsplit=1)[-1]))
 
     def test_resolves_libs_when_recursive_is_true(self, mock_program):
         url = "https://git.com/gitorg/repo"
         clone_project(url, recursive=True)
 
-        mock_program.from_url.assert_called_once_with(url, pathlib.Path(url.rsplit("/", maxsplit=1)[-1]), False)
+        mock_program.from_url.assert_called_once_with(url, pathlib.Path(url.rsplit("/", maxsplit=1)[-1]))
         mock_program.from_url.return_value.resolve_libraries.assert_called_once()
 
 


### PR DESCRIPTION
### Description

Fixes #62 

Removes the check for mbed-os.lib in the MbedProgram::from_url factory.

Changes LibraryReferences::in_ignore_path to use relative path 'parts'.

Removes auto generation of CMakeLists.txt in existing programs.

### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [x]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
