### PR TITLE
config: Add CMake supported application profiles variable

### DIFF
--- a/news/20201023.feature
+++ b/news/20201023.feature
@@ -1,0 +1,1 @@
+Add CMake variables for the supported application profiles to the generated CMake module

--- a/src/mbed_tools/build/_internal/cmake_file.py
+++ b/src/mbed_tools/build/_internal/cmake_file.py
@@ -60,6 +60,7 @@ def _render_mbed_config_cmake_template(
         "target_macros": target_build_attributes["macros"],
         "supported_form_factors": target_build_attributes["supported_form_factors"],
         "supported_c_libs": supported_c_libs,
+        "supported_application_profiles": target_build_attributes["supported_application_profiles"],
         "c_lib": target_build_attributes["c_lib"],
         "core": target_build_attributes["core"],
         "printf_lib": target_build_attributes["printf_lib"],

--- a/src/mbed_tools/build/_internal/templates/mbed_config.tmpl
+++ b/src/mbed_tools/build/_internal/templates/mbed_config.tmpl
@@ -15,6 +15,11 @@ list(APPEND MBED_TARGET_SUPPORTED_C_LIBS {% for supported_c_lib in supported_c_l
 {%- endfor %}
 )
 
+list(APPEND MBED_TARGET_SUPPORTED_APPLICATION_PROFILES {% for supported_application_profile in supported_application_profiles %}
+    {{supported_application_profile}}
+{%- endfor %}
+)
+
 list(APPEND MBED_TARGET_LABELS{% for label in labels %}
     {{label}}
 {%- endfor %}

--- a/tests/build/_internal/test_cmake_file.py
+++ b/tests/build/_internal/test_cmake_file.py
@@ -25,6 +25,7 @@ class TestGenerateCMakeListsFile(TestCase):
         mbed_target = "K64F"
         toolchain_name = "GCC"
         target["supported_c_libs"] = {toolchain_name.lower(): ["small", "std"]}
+        target["supported_application_profiles"] = ["full", "bare-metal"]
 
         result = generate_mbed_config_cmake_file(mbed_target, target, config, toolchain_name)
 
@@ -49,6 +50,7 @@ class TestRendersCMakeListsFile(TestCase):
         config = ConfigFactory()
         toolchain_name = "baz"
         target["supported_c_libs"] = {toolchain_name.lower(): ["small", "std"]}
+        target["supported_application_profiles"] = ["full", "bare-metal"]
         result = _render_mbed_config_cmake_template(target, config, toolchain_name, "target_name")
 
         for label in target["labels"] + target["extra_labels"]:
@@ -61,3 +63,6 @@ class TestRendersCMakeListsFile(TestCase):
             self.assertIn(toolchain, result)
             for supported_c_libs in toolchain:
                 self.assertIn(supported_c_libs, result)
+
+        for supported_application_profiles in target["supported_application_profiles"]:
+            self.assertIn(supported_application_profiles, result)


### PR DESCRIPTION

Please enter the commit message for your changes. Lines starting

### Description
- Added the target config supported_application_profiles support
- Updated the existing test to validate supported_application_profiles target config
- Added the news file
<!--
Please add any detail or context that would be useful to a reviewer.
-->



### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [ ]  This change is covered by existing or additional automated tests.
- [x]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
