### PR TITLE
ci: Use BLE_LED example

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -99,7 +99,7 @@ matrix:
 
     - <<: *mbed-tools-test
       name: "Test ble example (NRF52840_DK)"
-      env: EXAMPLE_NAME=mbed-os-example-ble TARGET_NAME=NRF52840_DK SUBEXAMPLE_NAME=BLE_Button CACHE_NAME=ble-ble-button-NRF52840_DK
+      env: EXAMPLE_NAME=mbed-os-example-ble TARGET_NAME=NRF52840_DK SUBEXAMPLE_NAME=BLE_LED CACHE_NAME=ble-ble-led-NRF52840_DK
 
     - <<: *mbed-tools-test
       name: "Test cellular example (WIO_3G)"

--- a/news/202010261100.misc
+++ b/news/202010261100.misc
@@ -1,0 +1,1 @@
+Update CI to use BLE LED example


### PR DESCRIPTION


### Description

<!--
Please add any detail or context that would be useful to a reviewer.
-->
From Mbed OS 6.4.0 onwards BLE_Button example isn't supported anymore,
therefore update the CI to use BLE_LED example instead

### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [ ]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
