### PR TITLE
travis: Use macOS for testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,20 +15,12 @@
 # limitations under the License.
 
 language: sh
-os: linux
-dist: xenial
-
-env:
-  global:
-    - deps_url="https://mbed-os-ci.s3-eu-west-1.amazonaws.com/jenkins-ci/deps"
-    - deps_dir="${HOME}/.cache/deps"
+os: osx
 
 cache:
   pip: true
   ccache: true
   directories:
-    # Cache arm-none-eabi compiler
-    - ${HOME}/.cache/deps
     # It looks like ccache for arm-none-eabi is not yet supported by Travis.
     # Therefore manually adding ccache directory to cache
     - ${HOME}/.ccache
@@ -37,9 +29,14 @@ before_install:
   - source travis-ci/functions.sh
 
 addons:
-  apt:
+  homebrew:
+    taps:
+    - ARMmbed/homebrew-formulae
     packages:
-    - ninja-build
+    - cmake
+    - ccache
+    - ninja
+    - arm-none-eabi-gcc
 
 matrix:
   include:

--- a/travis-ci/functions.sh
+++ b/travis-ci/functions.sh
@@ -14,52 +14,21 @@ set -o pipefail
 info() { echo -e "I: ${1}"; }
 
 #
-# Sources a pre-compiled GCC installation from AWS, installing the archive by
-#  extracting and prepending the executable directory to PATH.
-# Ccache is enabled for `arm-none-eabi-`.
-#
-# Note: Expects 'deps_url' and 'deps_dir' to already be defined.
+# Set up a development environment suitable for running our tests
 #
 _setup_build_env()
 {
-  # Enable Ccache in Travis
+  # Enable ccache for `arm-none-eabi-` and all other default toolchains.
   ccache -o compiler_check=content
   ccache -M 1G
-  pushd /usr/lib/ccache
-  sudo ln -s ../../bin/ccache arm-none-eabi-gcc
-  sudo ln -s ../../bin/ccache arm-none-eabi-g++
-  export "PATH=/usr/lib/ccache:${PATH}"
+  pushd /usr/local/opt/ccache/libexec
+  sudo ln -s ../bin/ccache arm-none-eabi-gcc
+  sudo ln -s ../bin/ccache arm-none-eabi-g++
+  export "PATH=/usr/local/opt/ccache/libexec:${PATH}:"
   popd
 
-  # Ignore shellcheck warnings: Variables defined in .travis.yml
-  # shellcheck disable=SC2154
-  local url="${deps_url}/gcc9-linux.tar.bz2"
-
-  # shellcheck disable=SC2154
-  local gcc_path="${deps_dir}/gcc/gcc-arm-none-eabi-9-2019-q4-major"
-
-  local archive="gcc.tar.bz2"
-
-  info "URL: ${url}"
-
-  if [ ! -d "${deps_dir}/gcc" ]; then
-
-    info "Downloading archive"
-    curl --location "${url}" --output "${deps_dir}/${archive}"
-    ls -al "${deps_dir}"
-
-    info "Extracting 'gcc'"
-    mkdir -p "${deps_dir}/gcc"
-    tar -xf "${deps_dir}/${archive}" -C "${deps_dir}/gcc"
-    rm "${deps_dir}/${archive}"
-
-  fi
-
-  info "Installing 'gcc'"
-  export "PATH=${PATH}:${gcc_path}/bin"
-
   arm-none-eabi-gcc --version
-  pip install --upgrade cmake
+  cmake --version
 }
 
 _clone_dependencies()


### PR DESCRIPTION

### Description

Travis CI recently reduced the number of Linux machines available for
open source project's CI to run on from around 1000 to 500. This has
resulted in very long waiting times for CI to complete. The macOS
machines look underutilized in comparison to the Linux ones, so use
macOS for testing instead of Linux to get better responsiveness.



### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [x]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
