### PR TITLE
travis: Get CMake from kitware repo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -64,6 +64,7 @@ matrix:
         - cd ..
         - _clone_dependencies
       script:
+        - echo mbedtools build -t GCC_ARM -m ${TARGET_NAME} -b ${PROFILE}
         - mbedtools build -t GCC_ARM -m ${TARGET_NAME} -b ${PROFILE}
         - ccache -s
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ env:
   global:
     - deps_url="https://mbed-os-ci.s3-eu-west-1.amazonaws.com/jenkins-ci/deps"
     - deps_dir="${HOME}/.cache/deps"
+    - PROFILE=develop
 
 cache:
   pip: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -64,7 +64,7 @@ matrix:
         - cd ..
         - _clone_dependencies
       script:
-        - mbedtools build -t GCC_ARM -m ${TARGET_NAME}
+        - mbedtools build -t GCC_ARM -m ${TARGET_NAME} -b ${PROFILE}
         - ccache -s
 
     - <<: *mbed-tools-test

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,8 +38,12 @@ before_install:
 
 addons:
   apt:
+    sources:
+      - sourceline: 'deb https://apt.kitware.com/ubuntu/ xenial main'
+        key_url: 'https://apt.kitware.com/keys/kitware-archive-latest.asc'
     packages:
-    - ninja-build
+      - cmake
+      - ninja-build
 
 matrix:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,6 +41,7 @@ addons:
     sources:
       - sourceline: 'deb https://apt.kitware.com/ubuntu/ xenial main'
         key_url: 'https://apt.kitware.com/keys/kitware-archive-latest.asc'
+      - sourceline: 'deb https://apt.kitware.com/ubuntu/ xenial-rc main'
     packages:
       - cmake
       - ninja-build

--- a/news/202011041130.misc
+++ b/news/202011041130.misc
@@ -1,0 +1,1 @@
+Install CMake in Travis CI from Kitware's APT repository.

--- a/travis-ci/functions.sh
+++ b/travis-ci/functions.sh
@@ -59,7 +59,15 @@ _setup_build_env()
   export "PATH=${PATH}:${gcc_path}/bin"
 
   arm-none-eabi-gcc --version
-  pip install --upgrade cmake
+
+  # Hide Travis-preinstalled CMake
+  # The Travis-preinstalled CMake is unfortunately not installed via apt, so we
+  # can't replace it with an apt-supplied version very easily. Additionally, we
+  # can't permit the Travis-preinstalled copy to survive, as the Travis default
+  # path lists the Travis CMake install location ahead of any place where apt
+  # would install CMake to. Instead of apt removing or upgrading to a new CMake
+  # version, we must instead delete the Travis copy of CMake.
+  sudo rm -rf /usr/local/cmake*
 }
 
 _clone_dependencies()


### PR DESCRIPTION
### Description

Pypi doesn't always have the lastest CMake releases, so use the official
Kitware apt repo instead.



### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [X]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
