### PR TITLE
config: Add CMake variable for the path of the local Mbed OS program

### DIFF
--- a/src/mbed_tools/build/_internal/cmake_file.py
+++ b/src/mbed_tools/build/_internal/cmake_file.py
@@ -15,24 +15,27 @@ TEMPLATE_NAME = "mbed_config.tmpl"
 
 
 def generate_mbed_config_cmake_file(
-    mbed_target_name: str, target_build_attributes: dict, config: Config, toolchain_name: str
+    mbed_target_name: str, target_build_attributes: dict, config: Config, toolchain_name: str, mbed_os_path: pathlib.Path
 ) -> str:
     """Generate the top-level CMakeLists.txt file containing the correct definitions for a build.
 
     Args:
-        mbed_target: the target the application is being built for
-        target_build_attributes: map of target attributes
-        program_path: the path to the local Mbed program
-        toolchain_name: the toolchain to be used to build the application
+        mbed_target_name: the target the application is being built for.
+        target_build_attributes: map of target attributes.
+        config: Config object holding information parsed from the mbed config system.
+        toolchain_name: the toolchain to be used to build the application.
+        mbed_os_path: the path to the local Mbed OS program.
 
     Returns:
         A string of rendered contents for the file.
     """
-    return _render_mbed_config_cmake_template(target_build_attributes, config, toolchain_name, mbed_target_name,)
+    return _render_mbed_config_cmake_template(
+        target_build_attributes, config, toolchain_name, mbed_target_name, mbed_os_path,
+    )
 
 
 def _render_mbed_config_cmake_template(
-    target_build_attributes: dict, config: Config, toolchain_name: str, target_name: str
+    target_build_attributes: dict, config: Config, toolchain_name: str, target_name: str, mbed_os_path: pathlib.Path
 ) -> str:
     """Renders the mbed_config template with the relevant information.
 
@@ -41,6 +44,7 @@ def _render_mbed_config_cmake_template(
         config: Config object holding information parsed from the mbed config system.
         toolchain_name: Name of the toolchain being used.
         target_name: Name of the target.
+        mbed_os_path: the path to the local Mbed OS program.
 
     Returns:
         The contents of the rendered CMake file.
@@ -70,6 +74,7 @@ def _render_mbed_config_cmake_template(
         "macros": sorted(macros, key=lambda macro: macro.name),
         "max_name_length": max(_max_attribute_length(options, "macro_name"), _max_attribute_length(macros, "name")),
         "max_value_length": max(_max_attribute_length(options, "value"), _max_attribute_length(macros, "value")),
+        "mbed_os_path": mbed_os_path,
     }
     return template.render(context)
 

--- a/src/mbed_tools/build/_internal/templates/mbed_config.tmpl
+++ b/src/mbed_tools/build/_internal/templates/mbed_config.tmpl
@@ -9,6 +9,7 @@ set(MBED_TARGET "{{target_name}}" CACHE STRING "")
 set(MBED_CPU_CORE "{{core}}" CACHE STRING "")
 set(MBED_C_LIB "{{c_lib}}" CACHE STRING "")
 set(MBED_PRINTF_LIB "{{printf_lib}}" CACHE STRING "")
+set(MBED_ROOT {{mbed_os_path}} CACHE INTERNAL "")
 
 list(APPEND MBED_TARGET_SUPPORTED_C_LIBS {% for supported_c_lib in supported_c_libs %}
     {{supported_c_lib}}

--- a/src/mbed_tools/build/config.py
+++ b/src/mbed_tools/build/config.py
@@ -25,7 +25,7 @@ def generate_config(target_name: str, toolchain: str, program: MbedProgram) -> p
     """
     target_build_attributes = get_target_by_name(target_name, program.mbed_os.targets_json_file)
     config = assemble_config(target_build_attributes, program.root, program.files.app_config_file)
-    cmake_file_contents = generate_mbed_config_cmake_file(target_name, target_build_attributes, config, toolchain)
+    cmake_file_contents = generate_mbed_config_cmake_file(target_name, target_build_attributes, config, toolchain, program.mbed_os.root)
     cmake_config_file_path = program.files.cmake_config_file
     write_file(cmake_config_file_path.parent, cmake_config_file_path.name, cmake_file_contents)
     return cmake_config_file_path

--- a/tests/build/_internal/test_cmake_file.py
+++ b/tests/build/_internal/test_cmake_file.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 from unittest import TestCase
+from pathlib import Path
 
 from tests.build._internal.config.factories import ConfigFactory
 from mbed_tools.build._internal.cmake_file import generate_mbed_config_cmake_file, _render_mbed_config_cmake_template
@@ -26,11 +27,12 @@ class TestGenerateCMakeListsFile(TestCase):
         toolchain_name = "GCC"
         target["supported_c_libs"] = {toolchain_name.lower(): ["small", "std"]}
         target["supported_application_profiles"] = ["full", "bare-metal"]
+        mbed_os_path = Path("path", "mbed_os")
 
-        result = generate_mbed_config_cmake_file(mbed_target, target, config, toolchain_name)
+        result = generate_mbed_config_cmake_file(mbed_target, target, config, toolchain_name, mbed_os_path)
 
         self.assertEqual(
-            result, _render_mbed_config_cmake_template(target, config, toolchain_name, mbed_target,),
+            result, _render_mbed_config_cmake_template(target, config, toolchain_name, mbed_target, mbed_os_path),
         )
 
 
@@ -51,7 +53,7 @@ class TestRendersCMakeListsFile(TestCase):
         toolchain_name = "baz"
         target["supported_c_libs"] = {toolchain_name.lower(): ["small", "std"]}
         target["supported_application_profiles"] = ["full", "bare-metal"]
-        result = _render_mbed_config_cmake_template(target, config, toolchain_name, "target_name")
+        result = _render_mbed_config_cmake_template(target, config, toolchain_name, "target_name", Path("path", "mbed_os"))
 
         for label in target["labels"] + target["extra_labels"]:
             self.assertIn(label, result)


### PR DESCRIPTION
`MBED_ROOT` is provided in the generated configuration
CMake module. It is used by application programs to add the subdirectory where the Mbed OS program is located.

### Description

<!--
Please add any detail or context that would be useful to a reviewer.
-->



### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [x]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
