### PR TITLE
Remove references to non-existent git branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -110,7 +110,7 @@ matrix:
 
     - <<: *mbed-tools-test
       name: "Test ble example (NRF52840_DK)"
-      env: EXAMPLE_NAME=mbed-os-example-ble TARGET_NAME=NRF52840_DK SUBEXAMPLE_NAME=BLE_LED CACHE_NAME=ble-ble-led-NRF52840_DK
+      env: EXAMPLE_NAME=mbed-os-example-ble TARGET_NAME=NRF52840_DK SUBEXAMPLE_NAME=BLE_Advertising CACHE_NAME=ble-ble-led-NRF52840_DK
 
     - <<: *mbed-tools-test
       name: "Test cellular example (WIO_3G)"

--- a/.travis.yml
+++ b/.travis.yml
@@ -59,6 +59,10 @@ matrix:
         - _setup_build_env
         # Install the changes added in the pull request
         - pip install .
+        - pip install -U 'prettytable<1.0'
+        - pip install -U 'future==0.16.0'
+        - pip install -U 'Jinja2>=2.10.1,<2.11'
+        - pip install -U 'intelhex>=1.3,<=2.2.1'
         - mbedtools --version
         # Leave mbed-tools directory to clone dependencies
         - cd ..

--- a/news/20201106115920.misc
+++ b/news/20201106115920.misc
@@ -1,0 +1,1 @@
+Remove references to non-existent git branches

--- a/src/mbed_tools/project/_internal/project_data.py
+++ b/src/mbed_tools/project/_internal/project_data.py
@@ -30,7 +30,7 @@ TARGETS_JSON_FILE_PATH = Path("targets", "targets.json")
 
 # Information written to mbed-os.lib
 MBED_OS_REFERENCE_URL = "https://github.com/ARMmbed/mbed-os"
-MBED_OS_REFERENCE_ID = "feature-cmake"
+MBED_OS_REFERENCE_ID = "master"
 
 # For some reason Mbed OS expects the default mbed_app.json to contain some target_overrides
 # for the K64F target. TODO: Find out why this wouldn't be defined in targets.json.

--- a/travis-ci/functions.sh
+++ b/travis-ci/functions.sh
@@ -73,7 +73,7 @@ _setup_build_env()
 _clone_dependencies()
 {
   # We use manual clone, with depth and single branch = the fastest
-  git clone --depth=1 --single-branch --branch feature-cmake https://github.com/ARMmbed/${EXAMPLE_NAME}.git
+  git clone --depth=1 --single-branch --branch development https://github.com/ARMmbed/${EXAMPLE_NAME}.git
 
   if [ -z ${SUBEXAMPLE_NAME} ]; then
       cd ${EXAMPLE_NAME}
@@ -81,7 +81,7 @@ _clone_dependencies()
       cd ${EXAMPLE_NAME}/${SUBEXAMPLE_NAME}
   fi
 
-  git clone --depth=1 --single-branch --branch feature-cmake https://github.com/ARMmbed/mbed-os.git
+  git clone --depth=1 --single-branch https://github.com/ARMmbed/mbed-os.git
 
   echo “” > mbed-os.lib
 

--- a/travis-ci/functions.sh
+++ b/travis-ci/functions.sh
@@ -4,7 +4,7 @@
 ## SPDX-License-Identifier: Apache-2.0
 ##
 
-set -o pipefail
+set -eo pipefail
 
 
 #


### PR DESCRIPTION


### Description

The feature-cmake branch has been merged to mbed-os and the
mbed-os-examples now. We should not generate CMake files referring to
this branch any longer, nor should our CI try to clone and use those
branches.



### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [x]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
