### PR TITLE
ci: Remove codecov token

### DIFF
--- a/azure-pipelines/steps/publish-code-coverage-results.yml
+++ b/azure-pipelines/steps/publish-code-coverage-results.yml
@@ -1,8 +1,5 @@
 steps:
-  # This script only runs for one set of unit tests (to avoid duplicate uploads) and will only run when the variable
-  # CODECOV_TOKEN is available, which means this step is disabled for PRs from forked repositories.
-  # Use "bash" rather than "script" to allow upload from all host platforms including Windows.
   - bash: |
-      bash <(curl -s https://codecov.io/bash) -Z -t $(CODECOV_TOKEN)
-    condition: and(succeeded(), eq(variables['uploadCoverage'], 'true'), ne(variables['CODECOV_TOKEN'], ''))
+      bash <(curl -s https://codecov.io/bash)
+    condition: and(succeeded(), eq(variables['uploadCoverage'], 'true'))
     displayName: 'Upload test coverage to codecov.io'

--- a/news/20201106150801.misc
+++ b/news/20201106150801.misc
@@ -1,0 +1,1 @@
+Use a tokenless upload to codecov from azure.


### PR DESCRIPTION
### Description

Codecov now apparently supports "tokenless uploads" from azure, which is
our current CI provider. Remove the codecov token from the pipeline
step.



<!--
Please add any detail or context that would be useful to a reviewer.
-->



### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [ ]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [x]  Additional tests are not required for this change (e.g. documentation update).
