### PR TITLE
Rename `checkout` to `deploy` command line option

### DIFF
--- a/news/202011091500.feature
+++ b/news/202011091500.feature
@@ -1,0 +1,1 @@
+Rename checkout to deploy command to improve usability.

--- a/src/mbed_tools/cli/main.py
+++ b/src/mbed_tools/cli/main.py
@@ -15,7 +15,7 @@ from mbed_tools.lib.logging import set_log_level, MbedToolsHandler
 
 from mbed_tools.cli.configure import configure
 from mbed_tools.cli.list_connected_devices import list_connected_devices
-from mbed_tools.cli.project_management import new, clone, checkout, libs
+from mbed_tools.cli.project_management import new, clone, deploy, libs
 from mbed_tools.cli.build import build
 
 CONTEXT_SETTINGS = dict(help_option_names=["-h", "--help"])
@@ -74,7 +74,7 @@ def cli(verbose: int, traceback: bool) -> None:
 cli.add_command(configure, "configure")
 cli.add_command(list_connected_devices, "devices")
 cli.add_command(new, "new")
-cli.add_command(checkout, "checkout")
+cli.add_command(deploy, "deploy")
 cli.add_command(clone, "clone")
 cli.add_command(libs, "libs")
 cli.add_command(build, "build")

--- a/src/mbed_tools/cli/project_management.py
+++ b/src/mbed_tools/cli/project_management.py
@@ -2,7 +2,7 @@
 # Copyright (C) 2020 Arm Mbed. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
-"""Project management commands: new, clone, checkout and libs."""
+"""Project management commands: new, clone, deploy and libs."""
 import os
 import pathlib
 
@@ -11,7 +11,7 @@ from typing import Any
 import click
 import tabulate
 
-from mbed_tools.project import initialise_project, clone_project, get_known_libs, checkout_project_revision
+from mbed_tools.project import initialise_project, clone_project, get_known_libs, deploy_project
 
 
 @click.command()
@@ -74,17 +74,19 @@ def libs(path: str) -> None:
     click.echo(tabulate.tabulate(table, headers=headers))
 
     if lib_data["unresolved"]:
-        click.echo(
-            "\nUnresolved libraries detected. Please run the `checkout` command to download library source code."
-        )
+        click.echo("\nUnresolved libraries detected. Please run the `deploy` command to download library source code.")
 
 
 @click.command()
 @click.argument("path", type=click.Path(), default=os.getcwd())
 @click.option(
-    "--force", "-f", is_flag=True, show_default=True, help="Force checkout, overwrites local uncommitted changes."
+    "--force",
+    "-f",
+    is_flag=True,
+    show_default=True,
+    help="Forces checkout of all library repositories at specified commit in the .lib file, overwrites local changes.",
 )
-def checkout(path: str, force: bool) -> None:
+def deploy(path: str, force: bool) -> None:
     """Checks out Mbed program library dependencies at the revision specified in the ".lib" files.
 
     Ensures all dependencies are resolved and the versions are synchronised to the version specified in the library
@@ -95,4 +97,4 @@ def checkout(path: str, force: bool) -> None:
     REVISION: The revision of the Mbed project to check out.
     """
     click.echo("Checking out all libraries to revisions specified in .lib files. Resolving any unresolved libraries.")
-    checkout_project_revision(pathlib.Path(path), force)
+    deploy_project(pathlib.Path(path), force)

--- a/src/mbed_tools/project/__init__.py
+++ b/src/mbed_tools/project/__init__.py
@@ -6,8 +6,8 @@
 
 * Creation of a new Mbed OS application.
 * Cloning of an existing Mbed OS program.
-* Checkout of a specific version of Mbed OS or library.
+* Deploy of a specific version of Mbed OS or library.
 """
 
-from mbed_tools.project.project import initialise_project, clone_project, checkout_project_revision, get_known_libs
+from mbed_tools.project.project import initialise_project, clone_project, deploy_project, get_known_libs
 from mbed_tools.project.mbed_program import MbedProgram

--- a/src/mbed_tools/project/_internal/libraries.py
+++ b/src/mbed_tools/project/_internal/libraries.py
@@ -70,7 +70,7 @@ class LibraryReferences:
         if list(self.iter_unresolved()):
             self.resolve()
 
-    def checkout(self, force: bool) -> None:
+    def deploy(self, force: bool) -> None:
         """Check out all resolved libs to revision specified in .lib files."""
         for lib in self.iter_resolved():
             repo = git_utils.init(lib.source_code_path)

--- a/src/mbed_tools/project/mbed_program.py
+++ b/src/mbed_tools/project/mbed_program.py
@@ -107,7 +107,7 @@ class MbedProgram:
         except ValueError as mbed_os_err:
             raise MbedOSNotFound(
                 f"Mbed OS was not found due to the following error: {mbed_os_err}"
-                "\nYou may need to resolve the mbed-os.lib reference. You can do this by performing a `checkout`."
+                "\nYou may need to resolve the mbed-os.lib reference. You can do this by performing a `deploy`."
             )
 
         return cls(program, mbed_os)
@@ -116,9 +116,9 @@ class MbedProgram:
         """Resolve all external dependencies defined in .lib files."""
         self.lib_references.resolve()
 
-    def checkout_libraries(self, force: bool = False) -> None:
+    def deploy_libraries(self, force: bool = False) -> None:
         """Check out all resolved libraries to revisions specified in .lib files."""
-        self.lib_references.checkout(force)
+        self.lib_references.deploy(force)
 
     def list_known_library_dependencies(self) -> List[MbedLibReference]:
         """Returns a list of all known library dependencies."""

--- a/src/mbed_tools/project/project.py
+++ b/src/mbed_tools/project/project.py
@@ -43,8 +43,8 @@ def initialise_project(path: pathlib.Path, create_only: bool) -> None:
         program.resolve_libraries()
 
 
-def checkout_project_revision(path: pathlib.Path, force: bool = False) -> None:
-    """Checkout a specific revision of the current Mbed project.
+def deploy_project(path: pathlib.Path, force: bool = False) -> None:
+    """Deploy a specific revision of the current Mbed project.
 
     This function also resolves and syncs all library dependencies to the revision specified in the library reference
     files.
@@ -52,11 +52,11 @@ def checkout_project_revision(path: pathlib.Path, force: bool = False) -> None:
     Args:
         path: Path to the Mbed project.
         project_revision: Revision of the Mbed project to check out.
-        force: Force overwrite uncommitted changes. If False, the checkout will fail if there are uncommitted local
+        force: Force overwrite uncommitted changes. If False, the deploy will fail if there are uncommitted local
                changes.
     """
     program = MbedProgram.from_existing(path, check_mbed_os=False)
-    program.checkout_libraries(force=force)
+    program.deploy_libraries(force=force)
     if program.has_unresolved_libraries():
         logger.info("Unresolved libraries detected, downloading library source code.")
         program.resolve_libraries()

--- a/tests/cli/test_project_management.py
+++ b/tests/cli/test_project_management.py
@@ -8,7 +8,7 @@ from unittest import TestCase, mock
 
 from click.testing import CliRunner
 
-from mbed_tools.cli.project_management import new, clone, checkout, libs
+from mbed_tools.cli.project_management import new, clone, deploy, libs
 
 
 @mock.patch("mbed_tools.cli.project_management.initialise_project", autospec=True)
@@ -40,8 +40,8 @@ class TestLibsCommand(TestCase):
         mocked_get_libs.assert_called_once()
 
 
-@mock.patch("mbed_tools.cli.project_management.checkout_project_revision", autospec=True)
-class TestCheckoutCommand(TestCase):
-    def test_calls_checkout_function_with_correct_args(self, mocked_checkout_project_revision):
-        CliRunner().invoke(checkout, ["path", "--force"])
-        mocked_checkout_project_revision.assert_called_once_with(pathlib.Path("path"), True)
+@mock.patch("mbed_tools.cli.project_management.deploy_project", autospec=True)
+class TestDeployCommand(TestCase):
+    def test_calls_deploy_function_with_correct_args(self, mocked_deploy_project):
+        CliRunner().invoke(deploy, ["path", "--force"])
+        mocked_deploy_project.assert_called_once_with(pathlib.Path("path"), True)

--- a/tests/project/_internal/test_libraries.py
+++ b/tests/project/_internal/test_libraries.py
@@ -49,31 +49,31 @@ class TestLibraryReferences(TestCase):
     @patchfs
     @mock.patch("mbed_tools.project._internal.git_utils.checkout", autospec=True)
     @mock.patch("mbed_tools.project._internal.git_utils.init", autospec=True)
-    def test_does_not_perform_checkout_if_no_git_ref_exists(self, mock_init, mock_checkout, mock_clone, fs):
+    def test_does_not_perform_deploy_if_no_git_ref_exists(self, mock_init, mock_checkout, mock_clone, fs):
         fs_root = pathlib.Path(fs, "foo")
         make_mbed_lib_reference(fs_root, ref_url="https://git", resolved=True)
 
         lib_refs = LibraryReferences(fs_root, ignore_paths=["mbed-os"])
-        lib_refs.checkout(force=False)
+        lib_refs.deploy(force=False)
 
         mock_checkout.assert_not_called()
 
     @patchfs
     @mock.patch("mbed_tools.project._internal.git_utils.checkout", autospec=True)
     @mock.patch("mbed_tools.project._internal.git_utils.init", autospec=True)
-    def test_performs_checkout_if_git_ref_exists(self, mock_init, mock_checkout, mock_clone, fs):
+    def test_performs_deploy_if_git_ref_exists(self, mock_init, mock_checkout, mock_clone, fs):
         fs_root = pathlib.Path(fs, "foo")
         lib = make_mbed_lib_reference(fs_root, ref_url="https://git#lajdhalk234", resolved=True)
 
         lib_refs = LibraryReferences(fs_root, ignore_paths=["mbed-os"])
-        lib_refs.checkout(force=False)
+        lib_refs.deploy(force=False)
 
         mock_checkout.assert_called_once_with(mock_init.return_value, lib.get_git_reference().ref, force=False)
 
     @patchfs
     @mock.patch("mbed_tools.project._internal.git_utils.checkout", autospec=True)
     @mock.patch("mbed_tools.project._internal.git_utils.init", autospec=True)
-    def test_resolve_does_not_perform_checkout_if_no_git_ref_exists(self, mock_init, mock_checkout, mock_clone, fs):
+    def test_resolve_does_not_perform_deploy_if_no_git_ref_exists(self, mock_init, mock_checkout, mock_clone, fs):
         fs_root = pathlib.Path(fs, "foo")
         make_mbed_lib_reference(fs_root, ref_url="https://git")
         mock_clone.side_effect = lambda url, dst_dir: dst_dir.mkdir()
@@ -86,7 +86,7 @@ class TestLibraryReferences(TestCase):
     @patchfs
     @mock.patch("mbed_tools.project._internal.git_utils.checkout", autospec=True)
     @mock.patch("mbed_tools.project._internal.git_utils.init", autospec=True)
-    def test_resolve_performs_checkout_if_git_ref_exists(self, mock_init, mock_checkout, mock_clone, fs):
+    def test_resolve_performs_deploy_if_git_ref_exists(self, mock_init, mock_checkout, mock_clone, fs):
         fs_root = pathlib.Path(fs, "foo")
         lib = make_mbed_lib_reference(fs_root, ref_url="https://git#lajdhalk234")
         mock_clone.side_effect = lambda url, dst_dir: dst_dir.mkdir()

--- a/tests/project/_internal/test_mbed_program.py
+++ b/tests/project/_internal/test_mbed_program.py
@@ -124,11 +124,11 @@ class TestLibReferenceHandling(TestCase):
     @mock.patch("mbed_tools.project.mbed_program.LibraryReferences", autospec=True)
     @mock.patch("mbed_tools.project.mbed_program.MbedProgramFiles")
     @mock.patch("mbed_tools.project.mbed_program.MbedOS")
-    def test_checkout_libraries_delegation(self, mbed_os, mbed_program_files, mock_lib_refs):
+    def test_deploy_libraries_delegation(self, mbed_os, mbed_program_files, mock_lib_refs):
         program = MbedProgram(mbed_program_files(), mbed_os())
-        program.checkout_libraries()
+        program.deploy_libraries()
 
-        program.lib_references.checkout.assert_called_once()
+        program.lib_references.deploy.assert_called_once()
 
     @patchfs
     def test_lists_all_known_libraries(self, fs):

--- a/tests/project/test_mbed_project.py
+++ b/tests/project/test_mbed_project.py
@@ -6,7 +6,7 @@ import pathlib
 
 from unittest import TestCase, mock
 
-from mbed_tools.project import initialise_project, clone_project, checkout_project_revision, get_known_libs
+from mbed_tools.project import initialise_project, clone_project, deploy_project, get_known_libs
 
 
 @mock.patch("mbed_tools.project.project.MbedProgram", autospec=True)
@@ -43,17 +43,17 @@ class TestCloneProject(TestCase):
 
 
 @mock.patch("mbed_tools.project.project.MbedProgram", autospec=True)
-class TestCheckoutProject(TestCase):
+class TestDeployProject(TestCase):
     def test_checks_out_libraries(self, mock_program):
         path = pathlib.Path("somewhere")
-        checkout_project_revision(path, force=False)
+        deploy_project(path, force=False)
 
         mock_program.from_existing.assert_called_once_with(path, False)
-        mock_program.from_existing.return_value.checkout_libraries.assert_called_once_with(force=False)
+        mock_program.from_existing.return_value.deploy_libraries.assert_called_once_with(force=False)
 
     def test_resolves_libs_if_unresolved_detected(self, mock_program):
         path = pathlib.Path("somewhere")
-        checkout_project_revision(path)
+        deploy_project(path)
 
         mock_program.from_existing.return_value.resolve_libraries.assert_called_once()
 

--- a/travis-ci/functions.sh
+++ b/travis-ci/functions.sh
@@ -85,5 +85,5 @@ _clone_dependencies()
 
   echo “” > mbed-os.lib
 
-  mbedtools checkout
+  mbedtools deploy
 }


### PR DESCRIPTION


### Description

<!--
Please add any detail or context that would be useful to a reviewer.
-->

To ensure good usability with the new Mbed tools the command line
options need to harmonize with the old tools.

Therefore change `checkout` to `deploy` by keeping the existing
functionality.

These are the following changes done:
* Docs updated
* Source files for project and CLI command updated to make sure api
calls mean the same externally and internally
* Unit tests updated with renamed test functions
* Travis job updated

### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [x]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
