### PR TITLE
Rename `init` to `new` command line option

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -138,10 +138,10 @@ matrix:
 
     # Mbed tools command line option test
     - <<: *mbed-tools-test
-      name: "Test init command"
-      env: NAME=test-init-cmd CACHE_NAME=test-init-cmd
+      name: "Test new command"
+      env: NAME=test-new-cmd CACHE_NAME=test-new-cmd
       script:
-        - mbedtools init test
+        - mbedtools new test
         - cd test
         - mbedtools build -t GCC_ARM -m K64F
         - ccache -s

--- a/news/202011101010.feature
+++ b/news/202011101010.feature
@@ -1,0 +1,1 @@
+Rename init to new command to improve usability.

--- a/src/mbed_tools/cli/main.py
+++ b/src/mbed_tools/cli/main.py
@@ -15,7 +15,7 @@ from mbed_tools.lib.logging import set_log_level, MbedToolsHandler
 
 from mbed_tools.cli.configure import configure
 from mbed_tools.cli.list_connected_devices import list_connected_devices
-from mbed_tools.cli.project_management import init, clone, checkout, libs
+from mbed_tools.cli.project_management import new, clone, checkout, libs
 from mbed_tools.cli.build import build
 
 CONTEXT_SETTINGS = dict(help_option_names=["-h", "--help"])
@@ -73,7 +73,7 @@ def cli(verbose: int, traceback: bool) -> None:
 
 cli.add_command(configure, "configure")
 cli.add_command(list_connected_devices, "devices")
-cli.add_command(init, "init")
+cli.add_command(new, "new")
 cli.add_command(checkout, "checkout")
 cli.add_command(clone, "clone")
 cli.add_command(libs, "libs")

--- a/src/mbed_tools/cli/project_management.py
+++ b/src/mbed_tools/cli/project_management.py
@@ -2,7 +2,7 @@
 # Copyright (C) 2020 Arm Mbed. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
-"""Project management commands: init, clone, checkout and libs."""
+"""Project management commands: new, clone, checkout and libs."""
 import os
 import pathlib
 
@@ -17,7 +17,7 @@ from mbed_tools.project import initialise_project, clone_project, get_known_libs
 @click.command()
 @click.option("--create-only", "-c", is_flag=True, show_default=True, help="Create a program without fetching mbed-os.")
 @click.argument("path", type=click.Path())
-def init(path: str, create_only: bool) -> None:
+def new(path: str, create_only: bool) -> None:
     """Creates a new Mbed project at the specified path. Downloads mbed-os and adds it to the project.
 
     PATH: Path to the destination directory for the project. Will be created if it does not exist.

--- a/tests/cli/test_project_management.py
+++ b/tests/cli/test_project_management.py
@@ -8,17 +8,17 @@ from unittest import TestCase, mock
 
 from click.testing import CliRunner
 
-from mbed_tools.cli.project_management import init, clone, checkout, libs
+from mbed_tools.cli.project_management import new, clone, checkout, libs
 
 
 @mock.patch("mbed_tools.cli.project_management.initialise_project", autospec=True)
-class TestInitCommand(TestCase):
-    def test_calls_init_function_with_correct_args(self, mock_initialise_project):
-        CliRunner().invoke(init, ["path", "--create-only"])
+class TestNewCommand(TestCase):
+    def test_calls_new_function_with_correct_args(self, mock_initialise_project):
+        CliRunner().invoke(new, ["path", "--create-only"])
         mock_initialise_project.assert_called_once_with(pathlib.Path("path"), True)
 
     def test_echos_mbed_os_message_when_required(self, mock_initialise_project):
-        result = CliRunner().invoke(init, ["path"])
+        result = CliRunner().invoke(new, ["path"])
 
         self.assertEqual(
             result.output,


### PR DESCRIPTION


### Description

<!--
Please add any detail or context that would be useful to a reviewer.
-->

To ensure good usability with the new Mbed tools the command line
options need to harmonize with the old tools.

Therefore change `init` to `new` by keeping the existing
functionality.

Source files for project and CLI command updated to make sure API
calls mean the same externally and internally

### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [x]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
