### PR TITLE
Rename `clone` to `import` command line option

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -145,3 +145,16 @@ matrix:
         - cd test
         - mbedtools compile -t GCC_ARM -m K64F
         - ccache -s
+
+    - <<: *mbed-tools-test
+      name: "Test import command"
+      env: NAME=test-import-cmd CACHE_NAME=test-import-cmd
+      script:
+        - mbedtools import mbed-os-example-ble
+        - cd mbed-os-example-ble
+        # Checkout the development branch on BLE example
+        - git checkout development
+        - cd BLE_Advertising
+        - mbedtools deploy
+        - mbedtools compile -t GCC_ARM -m K64F
+        - ccache -s

--- a/news/202011101200.feature
+++ b/news/202011101200.feature
@@ -1,0 +1,1 @@
+Rename clone to import command to improve usability.

--- a/src/mbed_tools/cli/main.py
+++ b/src/mbed_tools/cli/main.py
@@ -15,7 +15,7 @@ from mbed_tools.lib.logging import set_log_level, MbedToolsHandler
 
 from mbed_tools.cli.configure import configure
 from mbed_tools.cli.list_connected_devices import list_connected_devices
-from mbed_tools.cli.project_management import new, clone, deploy, libs
+from mbed_tools.cli.project_management import new, import_, deploy, libs
 from mbed_tools.cli.build import build
 from mbed_tools.cli.sterm import sterm
 
@@ -76,7 +76,7 @@ cli.add_command(configure, "configure")
 cli.add_command(list_connected_devices, "detect")
 cli.add_command(new, "new")
 cli.add_command(deploy, "deploy")
-cli.add_command(clone, "clone")
+cli.add_command(import_, "import")
 cli.add_command(libs, "libs")
 cli.add_command(build, "compile")
 cli.add_command(sterm, "sterm")

--- a/src/mbed_tools/cli/project_management.py
+++ b/src/mbed_tools/cli/project_management.py
@@ -2,7 +2,7 @@
 # Copyright (C) 2020 Arm Mbed. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
-"""Project management commands: new, clone, deploy and libs."""
+"""Project management commands: new, import_, deploy and libs."""
 import os
 import pathlib
 
@@ -11,7 +11,7 @@ from typing import Any
 import click
 import tabulate
 
-from mbed_tools.project import initialise_project, clone_project, get_known_libs, deploy_project
+from mbed_tools.project import initialise_project, import_project, get_known_libs, deploy_project
 
 
 @click.command()
@@ -39,7 +39,7 @@ def new(path: str, create_only: bool) -> None:
     show_default=True,
     help="Skip resolving program library dependencies after cloning.",
 )
-def clone(url: str, path: Any, skip_resolve_libs: bool) -> None:
+def import_(url: str, path: Any, skip_resolve_libs: bool) -> None:
     """Clone an Mbed project and library dependencies.
 
     URL: The git url of the remote project to clone.
@@ -54,7 +54,7 @@ def clone(url: str, path: Any, skip_resolve_libs: bool) -> None:
         click.echo(f"Destination path is '{path}'")
         path = pathlib.Path(path)
 
-    clone_project(url, path, not skip_resolve_libs)
+    import_project(url, path, not skip_resolve_libs)
 
 
 @click.command()

--- a/src/mbed_tools/project/__init__.py
+++ b/src/mbed_tools/project/__init__.py
@@ -9,5 +9,5 @@
 * Deploy of a specific version of Mbed OS or library.
 """
 
-from mbed_tools.project.project import initialise_project, clone_project, deploy_project, get_known_libs
+from mbed_tools.project.project import initialise_project, import_project, deploy_project, get_known_libs
 from mbed_tools.project.mbed_program import MbedProgram

--- a/src/mbed_tools/project/project.py
+++ b/src/mbed_tools/project/project.py
@@ -13,7 +13,7 @@ from mbed_tools.project.mbed_program import MbedProgram, parse_url
 logger = logging.getLogger(__name__)
 
 
-def clone_project(url: str, dst_path: Any = None, recursive: bool = False) -> None:
+def import_project(url: str, dst_path: Any = None, recursive: bool = False) -> None:
     """Clones an Mbed project from a remote repository.
 
     Args:

--- a/tests/cli/test_project_management.py
+++ b/tests/cli/test_project_management.py
@@ -8,7 +8,7 @@ from unittest import TestCase, mock
 
 from click.testing import CliRunner
 
-from mbed_tools.cli.project_management import new, clone, deploy, libs
+from mbed_tools.cli.project_management import new, import_, deploy, libs
 
 
 @mock.patch("mbed_tools.cli.project_management.initialise_project", autospec=True)
@@ -26,11 +26,11 @@ class TestNewCommand(TestCase):
         )
 
 
-@mock.patch("mbed_tools.cli.project_management.clone_project", autospec=True)
-class TestCloneCommand(TestCase):
-    def test_calls_clone_function_with_correct_args(self, mocked_clone_project):
-        CliRunner().invoke(clone, ["url", "dst"])
-        mocked_clone_project.assert_called_once_with("url", pathlib.Path("dst"), True)
+@mock.patch("mbed_tools.cli.project_management.import_project", autospec=True)
+class TestImportCommand(TestCase):
+    def test_calls_import_function_with_correct_args(self, mocked_import_project):
+        CliRunner().invoke(import_, ["url", "dst"])
+        mocked_import_project.assert_called_once_with("url", pathlib.Path("dst"), True)
 
 
 @mock.patch("mbed_tools.cli.project_management.get_known_libs", autospec=True)

--- a/tests/project/test_mbed_project.py
+++ b/tests/project/test_mbed_project.py
@@ -6,7 +6,7 @@ import pathlib
 
 from unittest import TestCase, mock
 
-from mbed_tools.project import initialise_project, clone_project, deploy_project, get_known_libs
+from mbed_tools.project import initialise_project, import_project, deploy_project, get_known_libs
 
 
 @mock.patch("mbed_tools.project.project.MbedProgram", autospec=True)
@@ -27,16 +27,16 @@ class TestInitialiseProject(TestCase):
 
 
 @mock.patch("mbed_tools.project.project.MbedProgram", autospec=True)
-class TestCloneProject(TestCase):
+class TestImportProject(TestCase):
     def test_clones_from_remote(self, mock_program):
         url = "https://git.com/gitorg/repo"
-        clone_project(url, recursive=False)
+        import_project(url, recursive=False)
 
         mock_program.from_url.assert_called_once_with(url, pathlib.Path(url.rsplit("/", maxsplit=1)[-1]))
 
     def test_resolves_libs_when_recursive_is_true(self, mock_program):
         url = "https://git.com/gitorg/repo"
-        clone_project(url, recursive=True)
+        import_project(url, recursive=True)
 
         mock_program.from_url.assert_called_once_with(url, pathlib.Path(url.rsplit("/", maxsplit=1)[-1]))
         mock_program.from_url.return_value.resolve_libraries.assert_called_once()


### PR DESCRIPTION
### Description

<!--
Please add any detail or context that would be useful to a reviewer.
-->

To ensure good usability with the new Mbed tools the command line
options need to harmonize with the old tools.

Therefore change `clone` to `import` by keeping the existing
functionality.

Update the following to reflect the changes done:
* Source files for project and CLI command updated to make sure API
calls mean the same externally and internally
* Unit tests with renamed test functions

### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [x]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
