### PR TITLE
Rename `devices` to `detect` command line option

### DIFF
--- a/news/202011191400.feature
+++ b/news/202011191400.feature
@@ -1,0 +1,1 @@
+Rename devices to detect command to improve usability.

--- a/src/mbed_tools/cli/main.py
+++ b/src/mbed_tools/cli/main.py
@@ -73,7 +73,7 @@ def cli(verbose: int, traceback: bool) -> None:
 
 
 cli.add_command(configure, "configure")
-cli.add_command(list_connected_devices, "devices")
+cli.add_command(list_connected_devices, "detect")
 cli.add_command(new, "new")
 cli.add_command(deploy, "deploy")
 cli.add_command(clone, "clone")

--- a/tests/cli/test_devices_command_integration.py
+++ b/tests/cli/test_devices_command_integration.py
@@ -14,7 +14,7 @@ from mbed_tools.lib.exceptions import ToolsError
 
 class TestDevicesCommandIntegration(TestCase):
     def test_devices_is_integrated(self):
-        self.assertEqual(cli.commands["devices"], list_connected_devices)
+        self.assertEqual(cli.commands["detect"], list_connected_devices)
 
 
 class TestClickGroupWithExceptionHandling(TestCase):


### PR DESCRIPTION


### Description

<!--
Please add any detail or context that would be useful to a reviewer.
-->

To ensure good usability with the new Mbed tools the command line
options need to harmonize with the old tools.

Therefore change `devices` to `detect` by keeping the existing
functionality.

### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [x]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
