### PR TITLE
travis: Use released CMake versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,6 @@ addons:
     sources:
       - sourceline: 'deb https://apt.kitware.com/ubuntu/ xenial main'
         key_url: 'https://apt.kitware.com/keys/kitware-archive-latest.asc'
-      - sourceline: 'deb https://apt.kitware.com/ubuntu/ xenial-rc main'
     packages:
       - cmake
       - ninja-build

--- a/news/202011191602.misc
+++ b/news/202011191602.misc
@@ -1,0 +1,1 @@
+Use released versions of CMake in Travis CI


### PR DESCRIPTION


### Description

Mbed OS will only depend on released versions of CMake now. Use released
versions of CMake by removing Kitware's release candidate APT
repository.

Fixes #104



### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [X]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
