### PR TITLE
Add --sterm option to the compile command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,7 @@ Pipfile.lock
 *.pyc
 __pycache__/
 *.egg-info/
-build/
+/build/
 
 # Coverage.py
 .coverage*

--- a/news/20201124142418.feature
+++ b/news/20201124142418.feature
@@ -1,0 +1,1 @@
+Add --sterm option to the compile command, allows users to open a serial terminal to the device after building and flashing their application.

--- a/src/mbed_tools/build/flash.py
+++ b/src/mbed_tools/build/flash.py
@@ -9,8 +9,7 @@ import os
 import pathlib
 import platform
 
-from mbed_tools.devices.device import Device
-from mbed_tools.devices.devices import get_connected_devices
+from mbed_tools.devices.devices import find_connected_device
 from mbed_tools.build.exceptions import BinaryFileNotFoundError, DeviceNotFoundError
 
 
@@ -24,28 +23,6 @@ def _flash_dev(disk: pathlib.Path, image_path: pathlib.Path) -> None:
     shutil.copy(image_path, disk, follow_symlinks=False)
     if not platform.system() == "Windows":
         os.sync()
-
-
-def _find_connected_device(mbed_target: str) -> Device:
-    """Check if requested device is connected to the system.
-
-    Look through the devices connected to the system and if a requested device is found then return it.
-
-    Args:
-       mbed_target: The name of the Mbed target to build for.
-
-    Returns:
-        Device if requested device is connected to system.
-
-    Raises:
-        DeviceNotFoundError: the requested board is not connected to the system
-    """
-    connected_devices = get_connected_devices()
-    for device in connected_devices.identified_devices:
-        if device.mbed_board.board_type.upper() == mbed_target.upper():
-            return device
-
-    raise DeviceNotFoundError("The target board you compiled for is not connected to your system.")
 
 
 def _build_binary_file_path(program_path: pathlib.Path, build_dir: pathlib.Path, hex_file: bool) -> pathlib.Path:
@@ -80,6 +57,6 @@ def flash_binary(program_path: pathlib.Path, build_dir: pathlib.Path, mbed_targe
        mbed_target: The name of the Mbed target to build for.
        hex_file: Use hex file.
     """
-    device = _find_connected_device(mbed_target)
+    device = find_connected_device(mbed_target)
     fw_file = _build_binary_file_path(program_path, build_dir, hex_file)
     _flash_dev(device.mount_points[0].resolve(), fw_file)

--- a/src/mbed_tools/build/flash.py
+++ b/src/mbed_tools/build/flash.py
@@ -9,8 +9,7 @@ import os
 import pathlib
 import platform
 
-from mbed_tools.devices.devices import find_connected_device
-from mbed_tools.build.exceptions import BinaryFileNotFoundError, DeviceNotFoundError
+from mbed_tools.build.exceptions import BinaryFileNotFoundError
 
 
 def _flash_dev(disk: pathlib.Path, image_path: pathlib.Path) -> None:
@@ -46,17 +45,19 @@ def _build_binary_file_path(program_path: pathlib.Path, build_dir: pathlib.Path,
     return fw_file
 
 
-def flash_binary(program_path: pathlib.Path, build_dir: pathlib.Path, mbed_target: str, hex_file: bool) -> None:
+def flash_binary(
+    mount_point: pathlib.Path, program_path: pathlib.Path, build_dir: pathlib.Path, mbed_target: str, hex_file: bool
+) -> None:
     """Flash binary onto a device.
 
     Look through the connected devices and flash the binary if the connected and built target matches.
 
     Args:
+       mount_point: Mount point of the target device.
        program_path: Path to the Mbed project.
        build_dir: Path to the CMake build folder.
        mbed_target: The name of the Mbed target to build for.
        hex_file: Use hex file.
     """
-    device = find_connected_device(mbed_target)
     fw_file = _build_binary_file_path(program_path, build_dir, hex_file)
-    _flash_dev(device.mount_points[0].resolve(), fw_file)
+    _flash_dev(mount_point, fw_file)

--- a/src/mbed_tools/cli/build.py
+++ b/src/mbed_tools/cli/build.py
@@ -10,7 +10,9 @@ import shutil
 import click
 
 from mbed_tools.build import build_project, generate_build_system, generate_config, flash_binary
+from mbed_tools.devices import find_connected_device
 from mbed_tools.project import MbedProgram
+from mbed_tools.sterm import terminal
 
 
 @click.command(name="compile", help="Build an Mbed project.")
@@ -35,6 +37,15 @@ from mbed_tools.project import MbedProgram
 @click.option(
     "--hex-file", is_flag=True, default=False, help="Use hex file, this option should be used with '-f/--flash' option",
 )
+@click.option(
+    "-s", "--sterm", is_flag=True, default=False, help="Launch a serial terminal to the device.",
+)
+@click.option(
+    "--baudrate",
+    default=9600,
+    show_default=True,
+    help="Change the serial baud rate (ignored unless --sterm is also given).",
+)
 def build(
     program_path: str,
     build_type: str,
@@ -43,6 +54,8 @@ def build(
     clean: bool = False,
     flash: bool = False,
     hex_file: bool = False,
+    sterm: bool = False,
+    baudrate: int = 9600,
 ) -> None:
     """Configure and build an Mbed project using CMake and Ninja.
 
@@ -60,6 +73,8 @@ def build(
        clean: Perform a clean build.
        flash: Flash the binary onto a device.
        hex_file: Use hex file, this option should be used with '-f/--flash' option.
+       sterm: Open a serial terminal to the connected target.
+       baudrate: Change the serial baud rate (ignored unless --sterm is also given).
     """
     program = MbedProgram.from_existing(pathlib.Path(program_path))
     mbed_config_file = program.files.cmake_config_file
@@ -76,10 +91,22 @@ def build(
     click.echo("Building Mbed project...")
     build_project(build_tree)
 
+    if flash or sterm:
+        dev = find_connected_device(mbed_target)
+
     if flash:
-        flash_binary(program.root, build_tree, mbed_target, hex_file)
+        flash_binary(dev.mount_points[0].resolve(), program.root, build_tree, mbed_target, hex_file)
     elif hex_file:
         click.echo("'--hex-file' option should be used with '-f/--flash' option")
+
+    if sterm:
+        if dev.serial_port is None:
+            raise click.ClickException(
+                f"The connected device {dev.mbed_board.board_name} does not have an associated serial port."
+                " Reconnect the device and try again."
+            )
+
+        terminal.run(dev.serial_port, baudrate)
 
 
 def _validate_target_and_toolchain_args(target: str, toolchain: str) -> None:

--- a/src/mbed_tools/devices/__init__.py
+++ b/src/mbed_tools/devices/__init__.py
@@ -10,6 +10,6 @@ Please see the documentation for mbed-targets for information on configuration o
 
 For the command line interface to the API see the package https://github.com/ARMmbed/mbed-tools
 """
-from mbed_tools.devices.devices import get_connected_devices
+from mbed_tools.devices.devices import get_connected_devices, find_connected_device
 from mbed_tools.devices.device import Device
 from mbed_tools.devices import exceptions

--- a/src/mbed_tools/devices/exceptions.py
+++ b/src/mbed_tools/devices/exceptions.py
@@ -12,3 +12,7 @@ class MbedDevicesError(ToolsError):
 
 class DeviceLookupFailed(MbedDevicesError):
     """Failed to look up data associated with the device."""
+
+
+class NoDevicesFound(MbedDevicesError):
+    """No Mbed Enabled devices were found."""

--- a/tests/build/test_flash.py
+++ b/tests/build/test_flash.py
@@ -8,21 +8,18 @@ import tempfile
 
 from unittest import TestCase, mock
 
-from mbed_tools.devices.device import ConnectedDevices
 from mbed_tools.build.flash import flash_binary, _build_binary_file_path, _flash_dev
-from mbed_tools.build.exceptions import BinaryFileNotFoundError, DeviceNotFoundError
+from mbed_tools.build.exceptions import BinaryFileNotFoundError
 
-from tests.build.factories import DeviceFactory, ConnectedDevicesFactory
+from tests.build.factories import DeviceFactory
 
 
-@mock.patch("mbed_tools.build.flash.find_connected_device")
 @mock.patch("mbed_tools.build.flash._build_binary_file_path")
 @mock.patch("mbed_tools.build.flash._flash_dev")
 class TestFlashBinary(TestCase):
-    def test_check_flashing(self, _flash_dev, _build_binary_file_path, _find_connected_device):
+    def test_check_flashing(self, _flash_dev, _build_binary_file_path):
         test_device = DeviceFactory()
 
-        _find_connected_device.return_value = test_device
         _flash_dev.return_value = True
 
         with tempfile.TemporaryDirectory() as tmpDir:
@@ -34,9 +31,8 @@ class TestFlashBinary(TestCase):
             bin_file.touch()
             _build_binary_file_path.return_value = bin_file
 
-            flash_binary(base_dir, build_dir, "TEST", False)
+            flash_binary(test_device.mount_points[0].resolve(), base_dir, build_dir, "TEST", False)
 
-            _find_connected_device.assert_called_once_with("TEST")
             _build_binary_file_path.assert_called_once_with(base_dir, build_dir, False)
             _flash_dev.assert_called_once_with(test_device.mount_points[0].resolve(), bin_file)
 

--- a/tests/build/test_flash.py
+++ b/tests/build/test_flash.py
@@ -9,13 +9,13 @@ import tempfile
 from unittest import TestCase, mock
 
 from mbed_tools.devices.device import ConnectedDevices
-from mbed_tools.build.flash import flash_binary, _build_binary_file_path, _find_connected_device, _flash_dev
+from mbed_tools.build.flash import flash_binary, _build_binary_file_path, _flash_dev
 from mbed_tools.build.exceptions import BinaryFileNotFoundError, DeviceNotFoundError
 
 from tests.build.factories import DeviceFactory, ConnectedDevicesFactory
 
 
-@mock.patch("mbed_tools.build.flash._find_connected_device")
+@mock.patch("mbed_tools.build.flash.find_connected_device")
 @mock.patch("mbed_tools.build.flash._build_binary_file_path")
 @mock.patch("mbed_tools.build.flash._flash_dev")
 class TestFlashBinary(TestCase):
@@ -72,23 +72,6 @@ class TestBuildBinFilePath(TestCase):
 
             with self.assertRaises(BinaryFileNotFoundError):
                 _build_binary_file_path(base_dir, build_dir, False)
-
-
-@mock.patch("mbed_tools.build.flash.get_connected_devices")
-class TestFindConnectedDevices(TestCase):
-    def test_check_missing_device(self, get_connected_devices):
-        get_connected_devices.return_value = ConnectedDevicesFactory()
-        with self.assertRaises(DeviceNotFoundError):
-            _find_connected_device("TEST")
-
-    def test_connected_device(self, get_connected_devices):
-        test_device = DeviceFactory()
-
-        test_connected_devices = ConnectedDevices()
-        test_connected_devices.identified_devices = [test_device]
-        get_connected_devices.return_value = test_connected_devices
-
-        self.assertEqual(_find_connected_device("TEST"), test_device)
 
 
 @mock.patch("mbed_tools.build.flash.shutil.copy")

--- a/tests/cli/test_sterm.py
+++ b/tests/cli/test_sterm.py
@@ -8,10 +8,28 @@ import pytest
 
 from click.testing import CliRunner
 
-from mbed_tools.cli.sterm import sterm, MbedDevicesError
+from mbed_tools.cli.sterm import sterm
+from mbed_tools.devices.exceptions import MbedDevicesError
 
 
-@mock.patch("mbed_tools.cli.sterm.terminal")
+@pytest.fixture
+def mock_terminal():
+    with mock.patch("mbed_tools.cli.sterm.terminal") as term:
+        yield term
+
+
+@pytest.fixture
+def mock_get_devices():
+    with mock.patch("mbed_tools.cli.sterm.get_connected_devices") as get_devs:
+        yield get_devs
+
+
+@pytest.fixture
+def mock_find_device():
+    with mock.patch("mbed_tools.cli.sterm.find_connected_device") as find_dev:
+        yield find_dev
+
+
 def test_launches_terminal_on_given_serial_port(mock_terminal):
     port = "tty.1111"
     CliRunner().invoke(sterm, ["--port", port])
@@ -19,7 +37,6 @@ def test_launches_terminal_on_given_serial_port(mock_terminal):
     mock_terminal.run.assert_called_once_with(port, 9600, echo=True)
 
 
-@mock.patch("mbed_tools.cli.sterm.terminal")
 def test_launches_terminal_with_given_baud_rate(mock_terminal):
     port = "tty.1111"
     baud = 115200
@@ -28,7 +45,6 @@ def test_launches_terminal_with_given_baud_rate(mock_terminal):
     mock_terminal.run.assert_called_once_with(port, baud, echo=True)
 
 
-@mock.patch("mbed_tools.cli.sterm.terminal")
 def test_launches_terminal_with_echo_off_when_specified(mock_terminal):
     port = "tty.1111"
     CliRunner().invoke(sterm, ["--port", port, "--echo", "off"])
@@ -36,29 +52,21 @@ def test_launches_terminal_with_echo_off_when_specified(mock_terminal):
     mock_terminal.run.assert_called_once_with(port, 9600, echo=False)
 
 
-@mock.patch("mbed_tools.cli.sterm.terminal")
-@mock.patch("mbed_tools.cli.sterm.get_connected_devices")
 def test_attempts_to_detect_device_if_no_port_given(mock_get_devices, mock_terminal):
     CliRunner().invoke(sterm, [])
 
     mock_get_devices.assert_called_once()
 
 
-@mock.patch("mbed_tools.cli.sterm.terminal")
-@mock.patch("mbed_tools.cli.sterm.get_connected_devices")
-def test_attempts_to_find_connected_target_if_target_given(mock_get_devices, mock_terminal):
+def test_attempts_to_find_connected_target_if_target_given(mock_find_device, mock_terminal):
     expected_port = "tty.k64f"
-    mock_get_devices.return_value = mock.Mock(
-        identified_devices=[mock.Mock(serial_port=expected_port, mbed_board=mock.Mock(board_type="K64F"))]
-    )
+    mock_find_device.return_value = mock.Mock(serial_port=expected_port, mbed_board=mock.Mock(board_type="K64F"))
 
     CliRunner().invoke(sterm, ["-m", "K64F"])
 
     mock_terminal.run.assert_called_once_with(expected_port, 9600, echo=True)
 
 
-@mock.patch("mbed_tools.cli.sterm.terminal")
-@mock.patch("mbed_tools.cli.sterm.get_connected_devices")
 def test_returns_serial_port_for_first_device_detected_if_no_target_given(mock_get_devices, mock_terminal):
     expected_port = "tty.k64f"
     mock_get_devices.return_value = mock.Mock(
@@ -73,21 +81,8 @@ def test_returns_serial_port_for_first_device_detected_if_no_target_given(mock_g
     mock_terminal.run.assert_called_once_with(expected_port, 9600, echo=True)
 
 
-@mock.patch("mbed_tools.cli.sterm.terminal")
-@mock.patch("mbed_tools.cli.sterm.get_connected_devices")
-def test_raises_exception_if_given_target_not_found(mock_get_devices, mock_terminal):
-    mock_get_devices.return_value = mock.Mock(
-        identified_devices=[mock.Mock(serial_port="", mbed_board=mock.Mock(board_type="DISCO"))]
-    )
-
-    with pytest.raises(MbedDevicesError):
-        CliRunner().invoke(sterm, ["-m", "K64F"], catch_exceptions=False)
-
-
-@mock.patch("mbed_tools.cli.sterm.terminal")
-@mock.patch("mbed_tools.cli.sterm.get_connected_devices")
-def test_raises_exception_if_no_devices_detected(mock_get_devices, mock_terminal):
+def test_raises_when_fails_to_find_default_device(mock_get_devices, mock_terminal):
     mock_get_devices.return_value = mock.Mock(identified_devices=[])
 
     with pytest.raises(MbedDevicesError):
-        CliRunner().invoke(sterm, ["-m", "K64F"], catch_exceptions=False)
+        CliRunner().invoke(sterm, [], catch_exceptions=False)


### PR DESCRIPTION
### Description

<!--
Please add any detail or context that would be useful to a reviewer.
-->

Allows users to open a serial terminal to the device after building and flashing their application.

### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [x]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
