### PR TITLE
Fetch and checkout default branch if no git hash given in .lib file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -157,3 +157,17 @@ matrix:
         - mbedtools deploy
         - mbedtools compile -t GCC_ARM -m K64F
         - ccache -s
+
+    - <<: *mbed-tools-test
+      name: "Test deploy command checks out tip of default branch"
+      env: NAME=test-deploy-cmd CACHE_NAME=test-deploy-cmd
+      script:
+        - mkdir deploy-test
+        - cd deploy-test
+        - echo "https://github.com/ARMmbed/mbed-os" > mbed-os.lib
+        - git clone --branch=latest https://github.com/ARMmbed/mbed-os.git
+        - mbedtools -vvv deploy
+        - cd mbed-os
+        - git branch --points-at origin/HEAD
+        - git branch --points-at origin/HEAD | grep -q "\*" || (echo "Couldn't
+          see current branch points at default branch" && false)

--- a/news/202011261100.bugfix
+++ b/news/202011261100.bugfix
@@ -1,0 +1,1 @@
+Use default branch from the remote repository, if no git hash in lib file. Fetch git repo before checkout when running `deploy` command.

--- a/src/mbed_tools/cli/project_management.py
+++ b/src/mbed_tools/cli/project_management.py
@@ -12,6 +12,7 @@ import click
 import tabulate
 
 from mbed_tools.project import initialise_project, import_project, get_known_libs, deploy_project
+from mbed_tools.project._internal import git_utils
 
 
 @click.command()
@@ -93,7 +94,9 @@ def _print_dependency_table(libs: List) -> None:
                 lib.reference_file.stem,
                 lib.get_git_reference().repo_url,
                 lib.source_code_path,
-                lib.get_git_reference().ref,
+                git_utils.get_default_branch(git_utils.get_repo(lib.source_code_path))
+                if not lib.get_git_reference().ref
+                else lib.get_git_reference().ref,
             ]
         )
 

--- a/src/mbed_tools/project/_internal/git_utils.py
+++ b/src/mbed_tools/project/_internal/git_utils.py
@@ -96,3 +96,21 @@ def get_repo(path: Path) -> git.Repo:
         raise VersionControlError(
             "Could not find a valid git repository at this path. Please perform a `git init` command."
         )
+
+
+def get_default_branch(repo: git.Repo) -> str:
+    """Get a default branch from an existing git.Repo.
+
+    Args:
+        repo: git.Repo object
+
+    Returns:
+        The default branch name as a string.
+
+    Raises:
+        VersionControlError: Could not find the default branch name.
+    """
+    try:
+        return str(repo.git.symbolic_ref("refs/remotes/origin/HEAD").rsplit("/", maxsplit=1)[-1])
+    except git.exc.GitCommandError as err:
+        raise VersionControlError(f"Could not resolve default repository branch name. Error from VCS: {err}")

--- a/src/mbed_tools/project/_internal/libraries.py
+++ b/src/mbed_tools/project/_internal/libraries.py
@@ -75,8 +75,12 @@ class LibraryReferences:
         for lib in self.iter_resolved():
             repo = git_utils.get_repo(lib.source_code_path)
             git_ref = lib.get_git_reference()
-            if git_ref.ref:
-                git_utils.checkout(repo, git_ref.ref, force=force)
+            repo.git.fetch()
+
+            if not git_ref.ref:
+                git_ref.ref = git_utils.get_default_branch(repo)
+
+            git_utils.checkout(repo, git_ref.ref, force=force)
 
     def iter_all(self) -> Generator[MbedLibReference, None, None]:
         """Iterate all library references in the tree.

--- a/tests/project/_internal/test_git_utils.py
+++ b/tests/project/_internal/test_git_utils.py
@@ -93,3 +93,18 @@ class TestCheckout:
 
         with pytest.raises(VersionControlError):
             git_utils.checkout(mock_repo, "bad")
+
+
+class TestGetDefaultBranch:
+    def test_returns_default_branch_name(self, mock_repo):
+        mock_repo().git.symbolic_ref.return_value = "refs/remotes/origin/main"
+
+        branch_name = git_utils.get_default_branch(mock_repo())
+
+        assert branch_name == "main"
+
+    def test_raises_version_control_error_when_git_command_fails(self, mock_repo):
+        mock_repo().git.symbolic_ref.side_effect = git_utils.git.exc.GitCommandError("git symbolic_ref", 255)
+
+        with pytest.raises(VersionControlError):
+            git_utils.get_default_branch(mock_repo())


### PR DESCRIPTION
### Description

<!--
Please add any detail or context that would be useful to a reviewer.
-->


Set default branch to master
Make sure we checkout `master` if there is no git hash present in the .lib file.

Perform fetch before checkout
Make sure we fetch git repo before performing checkout when using `deploy` command. This makes sure we have the latest changes in repo.

Tests have been updated to accommodate this issue.

### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [x]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).


Fixes https://github.com/ARMmbed/mbed-tools/issues/122