### PR TITLE
ci: Remove _clone_dependencies from travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -66,9 +66,17 @@ matrix:
         # Leave mbed-tools directory to clone dependencies
         - cd ..
       script:
-        - _clone_dependencies
+          # We use manual clone, with depth and single branch = the fastest
+        - git clone --depth=1 --single-branch --branch development https://github.com/ARMmbed/${EXAMPLE_NAME}.git
+        - |
+          if [ -z ${SUBEXAMPLE_NAME} ]; then
+              cd ${EXAMPLE_NAME}
+          else
+              cd ${EXAMPLE_NAME}/${SUBEXAMPLE_NAME}
+          fi
+        - mbedtools -vvv deploy
         - echo mbedtools compile -t GCC_ARM -m ${TARGET_NAME} -b ${PROFILE}
-        - mbedtools compile -t GCC_ARM -m ${TARGET_NAME} -b ${PROFILE}
+        - mbedtools -vvv compile -t GCC_ARM -m ${TARGET_NAME} -b ${PROFILE}
         - ccache -s
 
     - <<: *mbed-tools-test

--- a/news/20201127153832.misc
+++ b/news/20201127153832.misc
@@ -1,0 +1,1 @@
+Remove _clone_dependencies function from travis.

--- a/travis-ci/functions.sh
+++ b/travis-ci/functions.sh
@@ -69,21 +69,3 @@ _setup_build_env()
   # version, we must instead delete the Travis copy of CMake.
   sudo rm -rf /usr/local/cmake*
 }
-
-_clone_dependencies()
-{
-  # We use manual clone, with depth and single branch = the fastest
-  git clone --depth=1 --single-branch --branch development https://github.com/ARMmbed/${EXAMPLE_NAME}.git
-
-  if [ -z ${SUBEXAMPLE_NAME} ]; then
-      cd ${EXAMPLE_NAME}
-  else
-      cd ${EXAMPLE_NAME}/${SUBEXAMPLE_NAME}
-  fi
-
-  git clone --depth=1 --single-branch https://github.com/ARMmbed/mbed-os.git
-
-  echo “” > mbed-os.lib
-
-  mbedtools deploy
-}


### PR DESCRIPTION
### Description
Previously mbed-tools checked for the presence of an mbed-os.lib file
before performing an `import` or `deploy`. We worked around this in
our CI by creating an empty mbed-os.lib at the root of the project
before running the `deploy` command. mbed-tools no longer enforces this
policy, so we can remove the workaround.

After removing the workaround there seems to be no need for the
`_clone_dependencies` function. This commit removes the function. We
can't replace it with `mbedtools import` as that would cause many
unneeded copies of mbed-os to be cloned in the case of the BLE example,
which would slow the CI down significantly. For this reason we keep the
git clone step for the example and run `mbedtools deploy` in the
example/subexample folder to fetch other dependencies.

Fixes #126.

<!--
Please add any detail or context that would be useful to a reviewer.
-->



### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [x]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
