### PR TITLE
libraries: Save time by fetching specific refs

### DIFF
--- a/news/202011271738.feature
+++ b/news/202011271738.feature
@@ -1,0 +1,2 @@
+Save time by amking "deploy" only fetch a specific git reference when a .lib
+file contains a full git hash.

--- a/src/mbed_tools/project/_internal/libraries.py
+++ b/src/mbed_tools/project/_internal/libraries.py
@@ -75,10 +75,13 @@ class LibraryReferences:
         for lib in self.iter_resolved():
             repo = git_utils.get_repo(lib.source_code_path)
             git_ref = lib.get_git_reference()
-            repo.git.fetch()
 
             if not git_ref.ref:
+                repo.git.fetch()
                 git_ref.ref = git_utils.get_default_branch(repo)
+            else:
+                # Fetch only the requested ref
+                repo.git.fetch("origin", git_ref.ref)
 
             git_utils.checkout(repo, git_ref.ref, force=force)
 


### PR DESCRIPTION


### Description

Save time by fetching only the requested ref when a ref is given in a
.lib file.



### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [X]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
