### PR TITLE
Add back in accidentally deleted assert

### DIFF
--- a/tests/project/_internal/test_libraries.py
+++ b/tests/project/_internal/test_libraries.py
@@ -124,6 +124,8 @@ class TestLibraryReferences:
         lib_refs = LibraryReferences(fs_root, ignore_paths=["mbed-os"])
         lib_refs.fetch()
 
+        mock_clone.assert_not_called()
+
     def test_fetches_only_requested_ref(self, mock_repo, tmp_path):
         fs_root = pathlib.Path(tmp_path, "foo")
         fake_ref = "28eeee2b4c169739192600b92e7970dbbcabd8d0"


### PR DESCRIPTION



### Description

Add back in accidentally deleted assert in
test_does_not_resolve_references_in_ignore_paths().

Fixes: 2a28c185fec3 ("libraries: Save time by fetching specific refs")

### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [X]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
