### PR TITLE
ci: Add nightly release pipeline

### DIFF
--- a/azure-pipelines/build-and-deploy.yml
+++ b/azure-pipelines/build-and-deploy.yml
@@ -33,10 +33,6 @@ stages:
                 - script: |
                     python -m pip install --upgrade tox
                     tox -e py37
-                  displayName: "Run pytests"
-
-                - script: |
-                    python -m pip install --upgrade tox
                     tox -e pypirelease -- -p $TWINE_PASSWORD -u $TWINE_USERNAME
                   displayName: "PyPI release"
                   env:

--- a/azure-pipelines/build-and-deploy.yml
+++ b/azure-pipelines/build-and-deploy.yml
@@ -11,6 +11,7 @@ pr:
 
 stages:
   - stage: ReleaseToPyPI
+    condition: not(and(eq(variables['Build.SourceBranch'], 'refs/heads/master'), contains(variables['Build.SourceVersionMessage'], 'Prepare mbed-tools release')))
     displayName: 'Production Release'
     jobs:
       - deployment: PyPIRelease

--- a/azure-pipelines/prep-release.yml
+++ b/azure-pipelines/prep-release.yml
@@ -1,0 +1,38 @@
+trigger:
+  - none
+
+pr:
+  - none
+
+schedules:
+  - cron: "00 5 * * *"
+    displayName: "Prepare and tag release"
+    branches:
+      include:
+        - master
+    always: true
+
+jobs:
+  - job: TagRelease
+    displayName: 'Prepare mbed-tools release'
+    pool:
+      vmImage: 'ubuntu-latest'
+
+    steps:
+      - task: UsePythonVersion@0
+        inputs:
+          versionSpec: '3.7'
+
+      - script: |
+          # Set our user to the release bot account and ensure we've checked
+          # out the master branch.
+          git config --global user.name "Monty Bot"
+          git config --global user.email "monty-bot@arm.com"
+          git checkout master
+
+          python -m pip install --upgrade tox
+
+          tox -e preprelease
+        displayName: "Prepare mbed-tools release"
+        env:
+          GIT_TOKEN: $(GIT_TOKEN)

--- a/ci_scripts/prep-release
+++ b/ci_scripts/prep-release
@@ -12,7 +12,10 @@ generate-docs --output_dir docs/api
 license-files
 git add docs/api
 
-NEW_VERSION=$(python ci_scripts/bump_version.py -vvv -n news/)
+if ! NEW_VERSION=$(python ci_scripts/bump_version.py -vvv -n news/); then
+    printf "Nothing to do. Exiting.\n"
+    exit 0
+fi
 
 # Commit and tag new version
 # Towncrier will fail if it detects a news file that has not been committed to
@@ -27,3 +30,8 @@ git add ./CHANGELOG.md
 # Amend the git commit to include news file updates.
 git commit --amend -C HEAD
 git tag "${NEW_VERSION}"
+
+# Push the commit and tag to the remote. Relies on `GIT_TOKEN` environment
+# variable being set.
+git push "https://${GIT_TOKEN}@github.com/ARMmbed/mbed-tools.git" master
+git push "https://${GIT_TOKEN}@github.com/ARMmbed/mbed-tools.git" --tags

--- a/news/20201130143507.misc
+++ b/news/20201130143507.misc
@@ -1,0 +1,1 @@
+Create nightly release pipeline to auto commit generated files and tag a new release.

--- a/tox.ini
+++ b/tox.ini
@@ -45,6 +45,7 @@ usedevelop = True
 allowlist_externals = git
 passenv =
     HOME
+    GIT_TOKEN
 deps =
     mbed-tools-ci-scripts
 commands =


### PR DESCRIPTION
### Description
Add a pipeline to automate checking in auto generated files and tagging a new release. 
<!--
Please add any detail or context that would be useful to a reviewer.
-->



### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [ ]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
