### PR TITLE
Add `c_lib` and `printf_lib` to target config options

### DIFF
--- a/news/20201130184919.bugfix
+++ b/news/20201130184919.bugfix
@@ -1,0 +1,1 @@
+Add c_lib and printf_lib to target config options

--- a/src/mbed_tools/build/_internal/config/assemble_build_config.py
+++ b/src/mbed_tools/build/_internal/config/assemble_build_config.py
@@ -65,3 +65,5 @@ def _update_target_attributes(target_attributes: dict, cumulative_data: Cumulati
     target_attributes["features"] = cumulative_data.features
     target_attributes["components"] = cumulative_data.components
     target_attributes["macros"] = cumulative_data.macros
+    target_attributes["c_lib"] = cumulative_data.c_lib
+    target_attributes["printf_lib"] = cumulative_data.printf_lib

--- a/src/mbed_tools/build/_internal/config/cumulative_data.py
+++ b/src/mbed_tools/build/_internal/config/cumulative_data.py
@@ -21,6 +21,8 @@ class CumulativeData:
     extra_labels: Set[str] = field(default_factory=set)
     device_has: Set[str] = field(default_factory=set)
     macros: Set[str] = field(default_factory=set)
+    c_lib: str = field(default_factory=str)
+    printf_lib: str = field(default_factory=str)
 
     @classmethod
     def from_sources(cls, sources: Iterable[Source]) -> "CumulativeData":
@@ -41,7 +43,10 @@ def _modify_field(data: CumulativeData, key: str, value: Any) -> None:
     elif modifier == "remove":
         new_value = getattr(data, key) - set(value)
     else:
-        new_value = set(value)
+        if type(value) is str:
+            new_value = value
+        else:
+            new_value = set(value)
     setattr(data, key, new_value)
 
 

--- a/src/mbed_tools/build/_internal/config/source.py
+++ b/src/mbed_tools/build/_internal/config/source.py
@@ -86,6 +86,8 @@ class Source:
             "labels": target["labels"],
             "extra_labels": target["extra_labels"],
             "macros": target["macros"],
+            "c_lib": target["c_lib"],
+            "printf_lib": target["printf_lib"],
         }
         namespaced_overrides = _namespace_data(overrides, namespace)
 

--- a/tests/build/_internal/config/test_assemble_build_config.py
+++ b/tests/build/_internal/config/test_assemble_build_config.py
@@ -57,6 +57,8 @@ class TestAssembleConfigFromSourcesAndLibFiles(TestCase):
             "extra_labels": set(),
             "features": set("RED"),
             "components": set(),
+            "c_lib": "std",
+            "printf_lib": "minimal-printf",
         }
         mbed_lib_files = [
             {
@@ -119,6 +121,8 @@ class TestAssembleConfigFromSourcesAndLibFiles(TestCase):
             "extra_labels": set(),
             "features": set(),
             "components": set(),
+            "c_lib": "std",
+            "printf_lib": "minimal-printf",
         }
         mbed_lib_files = [
             {

--- a/tests/build/_internal/config/test_source.py
+++ b/tests/build/_internal/config/test_source.py
@@ -88,6 +88,8 @@ class TestSource(TestCase):
             extra_labels={"label_2"},
             config={"foo": "bar", "target.bool": True},
             macros=["MACRO_A"],
+            c_lib="std",
+            printf_lib="minimal-printf",
         )
 
         subject = Source.from_target(target)
@@ -103,6 +105,8 @@ class TestSource(TestCase):
                     "target.labels": target["labels"],
                     "target.extra_labels": target["extra_labels"],
                     "target.macros": target["macros"],
+                    "target.c_lib": target["c_lib"],
+                    "target.printf_lib": target["printf_lib"],
                 },
                 macros=[],
             ),

--- a/tests/regression/test_configure.py
+++ b/tests/regression/test_configure.py
@@ -1,0 +1,59 @@
+#
+# Copyright (C) 2020 Arm Mbed. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+
+import tempfile
+import pathlib
+import json
+
+from unittest import TestCase
+
+from click.testing import CliRunner
+
+from mbed_tools.cli.configure import configure
+
+target_json = json.dumps(
+    {
+        "TARGET": {
+            "core": None,
+            "trustzone": False,
+            "default_toolchain": "ARM",
+            "supported_toolchains": None,
+            "extra_labels": [],
+            "supported_form_factors": [],
+            "components": [],
+            "is_disk_virtual": False,
+            "macros": [],
+            "device_has": [],
+            "features": [],
+            "detect_code": [],
+            "c_lib": "std",
+            "bootloader_supported": False,
+            "static_memory_defines": True,
+            "printf_lib": "minimal-printf",
+            "supported_c_libs": {"arm": ["std"], "gcc_arm": ["std", "small"], "iar": ["std"]},
+            "supported_application_profiles": ["full"],
+        }
+    }
+)
+
+mbed_app_json = json.dumps(
+    {"target_overrides": {"*": {"target.c_lib": "small", "target.printf_lib": "minimal-printf"}}}
+)
+
+
+class TestConfigureRegression(TestCase):
+    def test_generate_config_called_with_correct_arguments(self):
+        with tempfile.TemporaryDirectory() as tmpDir:
+            tmpDirPath = pathlib.Path(tmpDir)
+            pathlib.Path(tmpDirPath / "mbed-os.lib").write_text("https://github.com/ARMmbed/mbed-os")
+            pathlib.Path(tmpDirPath / "mbed_app.json").write_text(mbed_app_json)
+            pathlib.Path(tmpDirPath / "mbed-os").mkdir()
+            pathlib.Path(tmpDirPath / "mbed-os" / "targets").mkdir()
+            pathlib.Path(tmpDirPath / "mbed-os" / "targets" / "targets.json").write_text(target_json)
+
+            result = CliRunner().invoke(
+                configure, ["-m", "Target", "-t", "gcc_arm", "-p", tmpDir], catch_exceptions=False
+            )
+            self.assertIn("mbed_config.cmake has been generated and written to", result.output)


### PR DESCRIPTION
### Description

<!--
Please add any detail or context that would be useful to a reviewer.
-->
The config options `c_lib` and `printf_lib` have been added to target configuration so that these options can be overridden by application configuration.

Regression test for `mbed-tools configure` command has been added.

Fixes https://github.com/ARMmbed/mbed-tools/issues/109

### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [x]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
