### PR TITLE
config: Always quote option values

### DIFF
--- a/news/20201201142709.bugfix
+++ b/news/20201201142709.bugfix
@@ -1,0 +1,1 @@
+Fix bug where we failed to handle config options that contain quotes (#125)

--- a/src/mbed_tools/build/_internal/templates/mbed_config.tmpl
+++ b/src/mbed_tools/build/_internal/templates/mbed_config.tmpl
@@ -65,7 +65,7 @@ set(MBED_CONFIG_DEFINITIONS
 # options
 {% for option in options -%}
 {% if option.value is not none -%}
-   {%if '{' in option.value|string or '(' in option.value|string %}"{% endif %}-D{{option.macro_name}}={{option.value}}{% if '}' in option.value|string or ')' in option.value|string %}"{% endif %}
+   "-D{{option.macro_name}}={{option.value|replace("\"", "\\\"")}}"
 {% endif %}
 {%- endfor %}
 # macros

--- a/tests/build/_internal/test_cmake_file.py
+++ b/tests/build/_internal/test_cmake_file.py
@@ -2,63 +2,58 @@
 # Copyright (C) 2020 Arm Mbed. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
+import pytest
+
 from tests.build._internal.config.factories import ConfigFactory
 from mbed_tools.build._internal.cmake_file import generate_mbed_config_cmake_file, _render_mbed_config_cmake_template
 
 
+TOOLCHAIN_NAME = "gcc"
+
+
+@pytest.fixture()
+def fake_target():
+    return {
+        "labels": ["foo"],
+        "extra_labels": ["morefoo"],
+        "features": ["bar"],
+        "components": ["baz"],
+        "macros": ["macbaz"],
+        "device_has": ["stuff"],
+        "c_lib": ["c_lib"],
+        "core": ["core"],
+        "printf_lib": ["printf_lib"],
+        "supported_form_factors": ["arduino"],
+        "supported_c_libs": {TOOLCHAIN_NAME: ["ginormous"]},
+        "supported_application_profiles": ["full", "bare-metal"],
+    }
+
+
 class TestGenerateCMakeListsFile:
-    def test_correct_arguments_passed(self):
-        target = dict()
-        target["labels"] = ["foo"]
-        target["extra_labels"] = ["morefoo"]
-        target["features"] = ["bar"]
-        target["components"] = ["baz"]
-        target["macros"] = ["macbaz"]
-        target["device_has"] = ["stuff"]
-        target["c_lib"] = ["c_lib"]
-        target["core"] = ["core"]
-        target["printf_lib"] = ["printf_lib"]
-        target["supported_form_factors"] = ["arduino"]
+    def test_correct_arguments_passed(self, fake_target):
         config = ConfigFactory()
         mbed_target = "K64F"
-        toolchain_name = "GCC"
-        target["supported_c_libs"] = {toolchain_name.lower(): ["small", "std"]}
-        target["supported_application_profiles"] = ["full", "bare-metal"]
 
-        result = generate_mbed_config_cmake_file(mbed_target, target, config, toolchain_name)
+        result = generate_mbed_config_cmake_file(mbed_target, fake_target, config, TOOLCHAIN_NAME)
 
-        assert result == _render_mbed_config_cmake_template(target, config, toolchain_name, mbed_target,)
+        assert result == _render_mbed_config_cmake_template(fake_target, config, TOOLCHAIN_NAME, mbed_target,)
 
 
 class TestRendersCMakeListsFile:
-    def test_returns_rendered_content(self):
-        target = dict()
-        target["labels"] = ["foo"]
-        target["extra_labels"] = ["morefoo"]
-        target["features"] = ["bar"]
-        target["components"] = ["baz"]
-        target["macros"] = ["macbaz"]
-        target["device_has"] = ["stuff"]
-        target["core"] = ["core"]
-        target["c_lib"] = ["c_lib"]
-        target["printf_lib"] = ["printf_lib"]
-        target["supported_form_factors"] = ["arduino"]
+    def test_returns_rendered_content(self, fake_target):
         config = ConfigFactory()
-        toolchain_name = "baz"
-        target["supported_c_libs"] = {toolchain_name.lower(): ["small", "std"]}
-        target["supported_application_profiles"] = ["full", "bare-metal"]
-        result = _render_mbed_config_cmake_template(target, config, toolchain_name, "target_name")
+        result = _render_mbed_config_cmake_template(fake_target, config, TOOLCHAIN_NAME, "target_name")
 
-        for label in target["labels"] + target["extra_labels"]:
+        for label in fake_target["labels"] + fake_target["extra_labels"]:
             assert label in result
 
-        for macro in target["features"] + target["components"] + [toolchain_name]:
+        for macro in fake_target["features"] + fake_target["components"] + [TOOLCHAIN_NAME]:
             assert macro in result
 
-        for toolchain in target["supported_c_libs"]:
+        for toolchain in fake_target["supported_c_libs"]:
             assert toolchain in result
             for supported_c_libs in toolchain:
                 assert supported_c_libs in result
 
-        for supported_application_profiles in target["supported_application_profiles"]:
+        for supported_application_profiles in fake_target["supported_application_profiles"]:
             assert supported_application_profiles in result

--- a/tests/build/_internal/test_cmake_file.py
+++ b/tests/build/_internal/test_cmake_file.py
@@ -4,8 +4,9 @@
 #
 import pytest
 
-from tests.build._internal.config.factories import ConfigFactory
+from tests.build._internal.config.factories import ConfigFactory, SourceFactory
 from mbed_tools.build._internal.cmake_file import generate_mbed_config_cmake_file, _render_mbed_config_cmake_template
+from mbed_tools.build._internal.config.config import _create_config_option
 
 
 TOOLCHAIN_NAME = "gcc"
@@ -57,3 +58,13 @@ class TestRendersCMakeListsFile:
 
         for supported_application_profiles in fake_target["supported_application_profiles"]:
             assert supported_application_profiles in result
+
+    def test_returns_quoted_content(self, fake_target):
+        config = ConfigFactory()
+        source = SourceFactory()
+
+        # Add an option whose value contains quotes to the config.
+        _create_config_option(config, "iotc-mqtt-host", '{"mqtt.2030.ltsapis.goog", IOTC_MQTT_PORT}', source)
+
+        result = _render_mbed_config_cmake_template(fake_target, config, TOOLCHAIN_NAME, "target_name")
+        assert '"-DMBED_CONF_IOTC_MQTT_HOST={\\"mqtt.2030.ltsapis.goog\\", IOTC_MQTT_PORT}"' in result

--- a/tests/build/_internal/test_cmake_file.py
+++ b/tests/build/_internal/test_cmake_file.py
@@ -2,13 +2,11 @@
 # Copyright (C) 2020 Arm Mbed. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
-from unittest import TestCase
-
 from tests.build._internal.config.factories import ConfigFactory
 from mbed_tools.build._internal.cmake_file import generate_mbed_config_cmake_file, _render_mbed_config_cmake_template
 
 
-class TestGenerateCMakeListsFile(TestCase):
+class TestGenerateCMakeListsFile:
     def test_correct_arguments_passed(self):
         target = dict()
         target["labels"] = ["foo"]
@@ -29,12 +27,10 @@ class TestGenerateCMakeListsFile(TestCase):
 
         result = generate_mbed_config_cmake_file(mbed_target, target, config, toolchain_name)
 
-        self.assertEqual(
-            result, _render_mbed_config_cmake_template(target, config, toolchain_name, mbed_target,),
-        )
+        assert result == _render_mbed_config_cmake_template(target, config, toolchain_name, mbed_target,)
 
 
-class TestRendersCMakeListsFile(TestCase):
+class TestRendersCMakeListsFile:
     def test_returns_rendered_content(self):
         target = dict()
         target["labels"] = ["foo"]
@@ -54,15 +50,15 @@ class TestRendersCMakeListsFile(TestCase):
         result = _render_mbed_config_cmake_template(target, config, toolchain_name, "target_name")
 
         for label in target["labels"] + target["extra_labels"]:
-            self.assertIn(label, result)
+            assert label in result
 
         for macro in target["features"] + target["components"] + [toolchain_name]:
-            self.assertIn(macro, result)
+            assert macro in result
 
         for toolchain in target["supported_c_libs"]:
-            self.assertIn(toolchain, result)
+            assert toolchain in result
             for supported_c_libs in toolchain:
-                self.assertIn(supported_c_libs, result)
+                assert supported_c_libs in result
 
         for supported_application_profiles in target["supported_application_profiles"]:
-            self.assertIn(supported_application_profiles, result)
+            assert supported_application_profiles in result


### PR DESCRIPTION
### Description

<!--
Please add any detail or context that would be useful to a reviewer.
-->


Always quote option values, being sure to escape literal quotes.
(Parenthesis don't need escaping within strings, so we also remove logic
to catch and handle the presence of parenthesis.) This prevents CMake
from getting confused when quotes are encounted within an option value
and making multiple partial list items from a single list item as
happens with the following mbed_lib.json snippet.

    "iotc-mqtt-host": {
        "help": "IOTC MQTT host configuration. Defaults to mqtt.2030.ltsapis.goog host and port number 8883 if undefined",
        "value": "{\"mqtt.2030.ltsapis.goog\", IOTC_MQTT_PORT}",
        "macro_name": "IOTC_MQTT_HOST"
    }

Which would produce the following bad CMake output (parsed as three list
items):

    "-DIOTC_MQTT_HOST={"mqtt.2030.ltsapis.goog", IOTC_MQTT_PORT}"

Now, after our changed, the output is good CMake output (parsed as one
list item):

    "-DIOTC_MQTT_HOST={\"mqtt.2030.ltsapis.goog\", IOTC_MQTT_PORT}"

Fixes #125





### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [ ]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
