### PR TITLE
pyproject: Add importlib-metadata license

### DIFF
--- a/news/20201202121845.misc
+++ b/news/20201202121845.misc
@@ -1,0 +1,1 @@
+Add importlib-metadata to packages with checked licences.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ chardet = "LGPL-2.1 - Accepted temporarily"
 pyudev = "LGPL-2.1 - Accepted temporarily"
 pdoc3 = "AGPL-3.0 - Accepted temporarily"
 zipp = "MIT"
+importlib-metadata = "Apache-2.0"
 
 [tool.setuptools_scm]
 local_scheme = "no-local-version"


### PR DESCRIPTION
### Description

The "Licence Report" script has started failing as it can't detect the
licence for the `importlib-metadata` package. This package has an
Apache-2.0 licence so is fine for our purposes. Add the licence to the
"Packages With Checked Licences" section of `pyproject.toml` to keep the
CI script happy.



<!--
Please add any detail or context that would be useful to a reviewer.
-->



### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [ ]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
