### PR TITLE
ci: Update license-files version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/ARMmbed/mbed-tools-ci-scripts.git
-    rev: 6b22e59771793679854ae520c9f109fa5385dc6d
+    rev: 2a605e0c715ad7f51a8f3853522f01a32846aba7
     hooks:
       - id: licensing
 

--- a/news/20201208124121.misc
+++ b/news/20201208124121.misc
@@ -1,0 +1,1 @@
+Update pre-commit license-files hook after update.


### PR DESCRIPTION
### Description

The license-files script was failing due to an update in the
`licenseheaders` dependency which broke the command line parsing. The
dependency has been pinned to a working version upstream so we need to
update the version for pre-commit.



<!--
Please add any detail or context that would be useful to a reviewer.
-->



### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [x]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
