### PR TITLE
ci: Add Python3.9 to test matrix

### DIFF
--- a/azure-pipelines/analyse-and-test.yml
+++ b/azure-pipelines/analyse-and-test.yml
@@ -43,6 +43,12 @@ stages:
               uploadCoverage: "false"
               tox.env: linting
 
+            Linting_Py_3_9:
+              python.version: '3.9'
+              vmImageName: ubuntu-latest
+              uploadCoverage: "false"
+              tox.env: linting
+
             Linux_Py_3_6:
               python.version: '3.6'
               vmImageName: ubuntu-latest
@@ -58,8 +64,14 @@ stages:
             Linux_Py_3_8:
               python.version: '3.8'
               vmImageName: ubuntu-latest
-              uploadCoverage: "true"
+              uploadCoverage: "false"
               tox.env: py38
+
+            Linux_Py_3_9:
+              python.version: '3.9'
+              vmImageName: ubuntu-latest
+              uploadCoverage: "true"
+              tox.env: py39
 
             Windows_Py_3_6:
               python.version: '3.6'
@@ -76,8 +88,14 @@ stages:
             Windows_Py_3_8:
               python.version: '3.8'
               vmImageName: windows-latest
-              uploadCoverage: "true"
+              uploadCoverage: "false"
               tox.env: py38
+
+            Windows_Py_3_9:
+              python.version: '3.9'
+              vmImageName: windows-latest
+              uploadCoverage: "true"
+              tox.env: py39
 
             macOS_Py_3_6:
               python.version: '3.6'
@@ -94,8 +112,14 @@ stages:
             macOS_Py_3_8:
               python.version: '3.8'
               vmImageName: macOS-latest
-              uploadCoverage: "true"
+              uploadCoverage: "false"
               tox.env: py38
+
+            macOS_Py_3_9:
+              python.version: '3.9'
+              vmImageName: macOS-latest
+              uploadCoverage: "true"
+              tox.env: py39
 
         pool:
           vmImage: $(vmImageName)

--- a/news/20201209160511.misc
+++ b/news/20201209160511.misc
@@ -1,0 +1,1 @@
+Add Python 3.9 testing to CI.

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = dev,linting,checknews,py36,py37,py38
+envlist = dev,linting,checknews,py36,py37,py38,py39
 minversion = 3.3.0
 # Activate isolated build environment. tox will use a virtual environment
 # to build a source distribution from the source tree.


### PR DESCRIPTION
### Description

Python 3.9 is now the version `brew` installs by default. Add testing
for Python 3.9 in the CI.

Fixes #146



<!--
Please add any detail or context that would be useful to a reviewer.
-->



### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [x]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
