### PR TITLE
  build: Add checks for CMake and Ninja installs

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,10 @@ follows:
 
 ## Installation
 
+`mbed-tools` relies on the Ninja build system and CMake.
+- CMake. [Install version 3.19.0 or newer for all operating systems](https://cmake.org/install/).
+- Ninja. [Install version 1.0 or newer for all operating systems](https://github.com/ninja-build/ninja/wiki/Pre-built-Ninja-packages).
+
 We recommend installing `mbed-tools` in a Python virtual environment to avoid dependency conflicts.
 
 To install the most recent production quality release use:

--- a/news/20201210131204.bugfix
+++ b/news/20201210131204.bugfix
@@ -1,0 +1,1 @@
+Emit more useful error messages if CMake or Ninja aren't found in PATH.

--- a/src/mbed_tools/build/build.py
+++ b/src/mbed_tools/build/build.py
@@ -22,6 +22,7 @@ def build_project(build_dir: pathlib.Path, target: Optional[str] = None) -> None
         build_dir: Path to the CMake build tree.
         target: The CMake target to build (e.g 'install')
     """
+    _check_ninja_found()
     target_flag = ["--target", target] if target is not None else []
     _cmake_wrapper("--build", str(build_dir), *target_flag)
 
@@ -34,6 +35,7 @@ def generate_build_system(source_dir: pathlib.Path, build_dir: pathlib.Path, pro
         build_dir: Path to the CMake build tree.
         profile: The Mbed build profile (develop, debug or release).
     """
+    _check_ninja_found()
     _cmake_wrapper("-S", str(source_dir), "-B", str(build_dir), "-GNinja", f"-DCMAKE_BUILD_TYPE={profile}")
 
 
@@ -41,5 +43,16 @@ def _cmake_wrapper(*cmake_args: str) -> None:
     try:
         logger.debug("Running CMake with args: %s", cmake_args)
         subprocess.run(["cmake", *cmake_args], check=True)
+    except FileNotFoundError:
+        raise MbedBuildError("Could not find CMake. Please ensure CMake is installed and added to PATH.")
     except subprocess.CalledProcessError:
         raise MbedBuildError("CMake invocation failed!")
+
+
+def _check_ninja_found() -> None:
+    try:
+        subprocess.run(["ninja", "--version"], check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    except FileNotFoundError:
+        raise MbedBuildError(
+            "Could not find the 'Ninja' build program. Please ensure 'Ninja' is installed and added to PATH."
+        )

--- a/tests/build/test_build.py
+++ b/tests/build/test_build.py
@@ -13,27 +13,21 @@ from mbed_tools.build.exceptions import MbedBuildError
 
 
 @pytest.fixture
-def cmake_wrapper():
-    with mock.patch("mbed_tools.build.build._cmake_wrapper") as cmake:
-        yield cmake
-
-
-@pytest.fixture
 def subprocess_run():
     with mock.patch("mbed_tools.build.build.subprocess.run", autospec=True) as subproc:
         yield subproc
 
 
 class TestBuildProject:
-    def test_invokes_cmake_with_correct_args(self, cmake_wrapper):
+    def test_invokes_cmake_with_correct_args(self, subprocess_run):
         build_project(build_dir="cmake_build", target="install")
 
-        cmake_wrapper.assert_called_once_with("--build", "cmake_build", "--target", "install")
+        subprocess_run.assert_called_with(["cmake", "--build", "cmake_build", "--target", "install"], check=True)
 
-    def test_invokes_cmake_with_correct_args_if_no_target_passed(self, cmake_wrapper):
+    def test_invokes_cmake_with_correct_args_if_no_target_passed(self, subprocess_run):
         build_project(build_dir="cmake_build")
 
-        cmake_wrapper.assert_called_once_with("--build", "cmake_build")
+        subprocess_run.assert_called_with(["cmake", "--build", "cmake_build"], check=True)
 
     def test_raises_build_error_if_cmake_invocation_fails(self, subprocess_run):
         subprocess_run.side_effect = subprocess.CalledProcessError(1, "")
@@ -43,13 +37,13 @@ class TestBuildProject:
 
 
 class TestConfigureProject:
-    def test_invokes_cmake_with_correct_args(self, cmake_wrapper):
+    def test_invokes_cmake_with_correct_args(self, subprocess_run):
         source_dir = "source_dir"
         build_dir = "cmake_build"
         profile = "debug"
 
         generate_build_system(source_dir, build_dir, profile)
 
-        cmake_wrapper.assert_called_once_with(
-            "-S", source_dir, "-B", build_dir, "-GNinja", f"-DCMAKE_BUILD_TYPE={profile}"
+        subprocess_run.assert_called_with(
+            ["cmake", "-S", source_dir, "-B", build_dir, "-GNinja", f"-DCMAKE_BUILD_TYPE={profile}"], check=True
         )

--- a/tests/build/test_build.py
+++ b/tests/build/test_build.py
@@ -5,20 +5,26 @@
 import pathlib
 
 from tempfile import TemporaryDirectory
-from unittest import TestCase, mock
+from unittest import mock
+
+import pytest
 
 from mbed_tools.build.build import build_project, generate_build_system
 from mbed_tools.build.exceptions import MbedBuildError
 
 
-class TestBuildProject(TestCase):
-    @mock.patch("mbed_tools.build.build._cmake_wrapper")
+@pytest.fixture
+def cmake_wrapper():
+    with mock.patch("mbed_tools.build.build._cmake_wrapper") as cmake:
+        yield cmake
+
+
+class TestBuildProject:
     def test_invokes_cmake_with_correct_args(self, cmake_wrapper):
         build_project(build_dir="cmake_build", target="install")
 
         cmake_wrapper.assert_called_once_with("--build", "cmake_build", "--target", "install")
 
-    @mock.patch("mbed_tools.build.build._cmake_wrapper")
     def test_invokes_cmake_with_correct_args_if_no_target_passed(self, cmake_wrapper):
         build_project(build_dir="cmake_build")
 
@@ -28,12 +34,11 @@ class TestBuildProject(TestCase):
         with TemporaryDirectory() as tmp_dir:
             nonexistent_build_dir = pathlib.Path(tmp_dir, "cmake_build")
 
-            with self.assertRaises(MbedBuildError):
+            with pytest.raises(MbedBuildError):
                 build_project(nonexistent_build_dir)
 
 
-@mock.patch("mbed_tools.build.build._cmake_wrapper")
-class TestConfigureProject(TestCase):
+class TestConfigureProject:
     def test_invokes_cmake_with_correct_args(self, cmake_wrapper):
         source_dir = "source_dir"
         build_dir = "cmake_build"


### PR DESCRIPTION
### Description

If CMake or Ninja is not found on PATH handle the builtin exception and
emit a more useful error message.

Fixes #149
<!--
Please add any detail or context that would be useful to a reviewer.
-->



### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [x]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
