### PR TITLE
config: Add support for `requires` config option

### DIFF
--- a/news/20201214165520.feature
+++ b/news/20201214165520.feature
@@ -1,0 +1,1 @@
+Add support for requires config option in mbed_app.json

--- a/src/mbed_tools/build/_internal/config/source.py
+++ b/src/mbed_tools/build/_internal/config/source.py
@@ -3,12 +3,13 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 """Configuration source abstraction."""
-import json
 import logging
 
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Iterable, Any
+from typing import Iterable
+
+from mbed_tools.lib.json_helpers import decode_json_file
 
 logger = logging.getLogger(__name__)
 
@@ -38,7 +39,7 @@ class Source:
             mbed_lib_path: Path to mbed_lib.json file
             target_labels: Labels for which "target_overrides" should apply
         """
-        file_contents = _decode_json_file(mbed_lib_path)
+        file_contents = decode_json_file(mbed_lib_path)
         namespace = file_contents["name"]
 
         return cls.from_file_contents(
@@ -53,7 +54,7 @@ class Source:
             mbed_app_path: Path to mbed_app.json file
             target_labels: Labels for which "target_overrides" should apply
         """
-        file_contents = _decode_json_file(mbed_app_path)
+        file_contents = decode_json_file(mbed_app_path)
         return cls.from_file_contents(
             file_name=str(mbed_app_path), file_contents=file_contents, namespace="app", target_labels=target_labels
         )
@@ -127,11 +128,3 @@ def _namespace_data(data: dict, namespace: str) -> dict:
             key = f"{namespace}.{key}"
         namespaced[key] = value
     return namespaced
-
-
-def _decode_json_file(path: Path) -> Any:
-    try:
-        return json.loads(path.read_text())
-    except json.JSONDecodeError:
-        logger.error(f"Failed to decode JSON data in the file located at '{path}'")
-        raise

--- a/src/mbed_tools/build/_internal/find_files.py
+++ b/src/mbed_tools/build/_internal/find_files.py
@@ -5,7 +5,9 @@
 """Find files in MbedOS program directory."""
 from pathlib import Path
 import fnmatch
-from typing import Callable, Iterable, Optional, List, Tuple
+from typing import Callable, Iterable, Optional, List, Tuple, Any, Set
+
+from mbed_tools.lib.json_helpers import decode_json_file
 
 
 def find_files(filename: str, directory: Path) -> List[Path]:
@@ -64,6 +66,56 @@ def _find_files(filename: str, directory: Path, filters: Optional[List[Callable]
 def filter_files(files: Iterable[Path], filters: Iterable[Callable]) -> Iterable[Path]:
     """Filter given paths to files using filter callables."""
     return [file for file in files if all(f(file) for f in filters)]
+
+
+class RequiresFilter:
+    """Filter out mbed libraries not needed by application.
+
+     The 'requires' config option in mbed_app.json can specify list of mbed
+    libraries (mbed_lib.json) that application requires. Apply 'requires'
+    filter to remove mbed_lib.json files not required by application.
+    """
+
+    def __init__(self, requires: Iterable[str]):
+        """Initialise the filter attributes.
+
+        Args:
+            requires: List of required mbed libraries.
+        """
+        self._requires = requires
+
+    def __call__(self, files: Iterable[Path]) -> Iterable[Path]:
+        """Apply requires filter and remove mbed_lib.json files not required by application."""
+        requires_filtered_files: Set[Path] = set()
+        return self.apply_requires_filter(requires_filtered_files, files, self._requires)
+
+    @staticmethod
+    def apply_requires_filter(
+        requires_filtered_files: set, files: Iterable[Path], requires: Iterable[str]
+    ) -> Iterable[Path]:
+        """Remove mbed_lib.json files not required by application."""
+        for required_mbed_lib in requires:
+            for mbed_lib_path in files:
+                lib_contents = decode_json_file(mbed_lib_path)
+
+                if required_mbed_lib == RequiresFilter.get_mbed_lib_name(lib_contents):
+                    requires_filtered_files.add(mbed_lib_path)
+
+                    RequiresFilter.apply_requires_filter(
+                        requires_filtered_files, files, RequiresFilter.get_mbed_lib_requires(lib_contents)
+                    )
+
+        return requires_filtered_files
+
+    @staticmethod
+    def get_mbed_lib_requires(lib_contents: Any) -> Any:
+        """Get list of mbed libraries required by appplication."""
+        return lib_contents["requires"] if "requires" in lib_contents else []
+
+    @staticmethod
+    def get_mbed_lib_name(lib_contents: Any) -> Any:
+        """Get mbed library name."""
+        return lib_contents["name"]
 
 
 class LabelFilter:

--- a/src/mbed_tools/lib/json_helpers.py
+++ b/src/mbed_tools/lib/json_helpers.py
@@ -1,0 +1,21 @@
+#
+# Copyright (C) 2020 Arm Mbed. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+"""Helpers for json related functions."""
+import json
+import logging
+
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+def decode_json_file(path: Path) -> Any:
+    """Return the contents of json file."""
+    try:
+        return json.loads(path.read_text())
+    except json.JSONDecodeError:
+        logger.error(f"Failed to decode JSON data in the file located at '{path}'")
+        raise

--- a/tests/build/_internal/config/test_source.py
+++ b/tests/build/_internal/config/test_source.py
@@ -7,11 +7,11 @@ import pathlib
 import tempfile
 from unittest import TestCase
 
+from mbed_tools.lib.json_helpers import decode_json_file
 from mbed_tools.build._internal.config.source import (
     Source,
     _namespace_data,
     _filter_target_overrides,
-    _decode_json_file,
 )
 
 
@@ -141,6 +141,6 @@ class TestDecodeJSONFile(TestCase):
 
             with self.assertRaises(json.JSONDecodeError):
                 with self.assertLogs(level="ERROR") as logger:
-                    _decode_json_file(tmp_file)
+                    decode_json_file(tmp_file)
 
                     self.assertIn(str(tmp_file), logger.output)

--- a/tests/build/test_generate_config.py
+++ b/tests/build/test_generate_config.py
@@ -395,3 +395,23 @@ def test_settings_from_multiple_libs_included(matching_target_and_filter, progra
 
     assert "MBED_CONF_PLATFORM_STDIO_BAUD_RATE=9600" in config_text
     assert "MBED_LFS_READ_SIZE=64" in config_text
+
+
+def test_requires_config_option(program):
+    create_mbed_app_json(program.root, requires=["bare-metal"])
+    create_mbed_lib_json(program.mbed_os.root / "bare-metal" / "mbed_lib.json", "bare-metal", requires=["platform"])
+    create_mbed_lib_json(
+        program.mbed_os.root / "platform" / "mbed_lib.json", "platform", config={"stdio-baud-rate": {"value": 9600}},
+    )
+    create_mbed_lib_json(
+        program.mbed_os.root / "storage" / "mbed_lib.json",
+        "filesystem",
+        config={"read_size": {"macro_name": "MBED_LFS_READ_SIZE", "value": 64}},
+    )
+
+    generate_config("K64F", "GCC_ARM", program)
+
+    config_text = program.files.cmake_config_file.read_text()
+
+    assert "MBED_CONF_PLATFORM_STDIO_BAUD_RATE=9600" in config_text
+    assert "MBED_LFS_READ_SIZE=64" not in config_text

--- a/tests/lib/test_json_helpers.py
+++ b/tests/lib/test_json_helpers.py
@@ -1,0 +1,17 @@
+#
+# Copyright (C) 2020 Arm Mbed. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+import json
+
+import pytest
+
+from mbed_tools.lib.json_helpers import decode_json_file
+
+
+def test_invalid_json(tmp_path):
+    lib_json_path = tmp_path / "mbed_lib.json"
+    lib_json_path.write_text("name")
+
+    with pytest.raises(json.JSONDecodeError):
+        decode_json_file(lib_json_path)


### PR DESCRIPTION
### Description

<!--
Please add any detail or context that would be useful to a reviewer.
-->

Support for a config option `requires` in `mbed_app.json` is added
which enables application to choose required mbed libraries. if
`requires` is mentioned in `mbed_app.json` then only those mbed
libraries and other libraries those mbed libraries depend on will be
selected. Other mbed libraries are ignored.

Fixes https://github.com/ARMmbed/mbed-tools/issues/127.

### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [x]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
