### PR TITLE
Add support for custom_targets.json

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,8 @@ repos:
     hooks:
       - id: licenseheaders
         exclude: \.yaml$|\.yml$
-        args: ["-t", "ci_scripts/templates/.copyright.tmpl", "-cy", "-f"]
+        args: ["-s", "ci_scripts/licenseheaders.json", "-t",
+        "ci_scripts/templates/.copyright.tmpl", "-cy", "-f"]
 
   - repo: https://github.com/psf/black
     rev: 19.10b0

--- a/.travis.yml
+++ b/.travis.yml
@@ -163,6 +163,20 @@ matrix:
         - ccache -s
 
     - <<: *mbed-tools-test
+      name: "Test custom target"
+      env: NAME=test-import-cmd CACHE_NAME=test-import-cmd
+      script:
+        - mbedtools new custom-target-test
+        - cd custom-target-test
+        - cp $TRAVIS_BUILD_DIR/travis-ci/test-data/custom_targets.json .
+        - mkdir TARGET_IMAGINARYBOARD
+        - cp $TRAVIS_BUILD_DIR/travis-ci/test-data/TARGET_IMAGINARYBOARD/* TARGET_IMAGINARYBOARD
+        - cp mbed-os/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L475xG/TARGET_DISCO_L475VG_IOT01A/P* TARGET_IMAGINARYBOARD
+        - sed -i '/add_subdirectory(${MBED_PATH})/i add_subdirectory(TARGET_IMAGINARYBOARD)' CMakeLists.txt
+        - mbedtools compile -t GCC_ARM -m IMAGINARYBOARD
+        - ccache -s
+
+    - <<: *mbed-tools-test
       name: "Test deploy command checks out tip of default branch"
       env: NAME=test-deploy-cmd CACHE_NAME=test-deploy-cmd
       script:

--- a/ci_scripts/licenseheaders.json
+++ b/ci_scripts/licenseheaders.json
@@ -1,0 +1,15 @@
+{
+    "cmake": {
+        "extensions": [],
+        "filenames": ["CMakeLists.txt"],
+        "keepFirst": "",
+        "blockCommentStartPattern": "",
+        "blockCommentEndPattern": "",
+        "lineCommentStartPattern": "^\\s*#",
+        "lineCommentEndPattern": "",
+        "headerStartLine": "",
+        "headerEndLine": "",
+        "headerLinePrefix": "# ",
+        "headerLineSuffix": ""
+    }
+}

--- a/news/20201222090211.feature
+++ b/news/20201222090211.feature
@@ -1,0 +1,1 @@
+Support custom_targets.json.

--- a/src/mbed_tools/build/_internal/cmake_file.py
+++ b/src/mbed_tools/build/_internal/cmake_file.py
@@ -13,22 +13,8 @@ TEMPLATES_DIRECTORY = pathlib.Path("_internal", "templates")
 TEMPLATE_NAME = "mbed_config.tmpl"
 
 
-def generate_mbed_config_cmake_file(mbed_target_name: str, config: Config, toolchain_name: str) -> str:
-    """Generate mbed_config.cmake containing the correct definitions for a build.
-
-    Args:
-        mbed_target_name: the target the application is being built for
-        config: Config object holding information parsed from the mbed config system.
-        toolchain_name: the toolchain to be used to build the application
-
-    Returns:
-        A string of rendered contents for the file.
-    """
-    return _render_mbed_config_cmake_template(config, toolchain_name, mbed_target_name,)
-
-
-def _render_mbed_config_cmake_template(config: Config, toolchain_name: str, target_name: str) -> str:
-    """Renders the mbed_config template with the relevant information.
+def render_mbed_config_cmake_template(config: Config, toolchain_name: str, target_name: str) -> str:
+    """Renders the mbed_config jinja template with the target and project config settings.
 
     Args:
         config: Config object holding information parsed from the mbed config system.
@@ -36,7 +22,7 @@ def _render_mbed_config_cmake_template(config: Config, toolchain_name: str, targ
         target_name: Name of the target.
 
     Returns:
-        The contents of the rendered CMake file.
+        The rendered mbed_config template.
     """
     env = jinja2.Environment(loader=jinja2.PackageLoader("mbed_tools.build", str(TEMPLATES_DIRECTORY)),)
     template = env.get_template(TEMPLATE_NAME)

--- a/src/mbed_tools/build/_internal/write_files.py
+++ b/src/mbed_tools/build/_internal/write_files.py
@@ -7,8 +7,8 @@ import pathlib
 from mbed_tools.build.exceptions import InvalidExportOutputDirectory
 
 
-def write_file(output_directory: pathlib.Path, file_name: str, file_contents: str) -> None:
-    """Writes out a file to a directory.
+def write_file(file_path: pathlib.Path, file_contents: str) -> None:
+    """Writes out a string to a file.
 
     If the intermediate directories to the output directory don't exist,
     this function will create them.
@@ -19,9 +19,9 @@ def write_file(output_directory: pathlib.Path, file_name: str, file_contents: st
     Raises:
         InvalidExportOutputDirectory: it's not possible to export to the output directory provided
     """
+    output_directory = file_path.parent
     if output_directory.is_file():
         raise InvalidExportOutputDirectory("Output directory cannot be a path to a file.")
 
     output_directory.mkdir(parents=True, exist_ok=True)
-    output_file = output_directory.joinpath(file_name)
-    output_file.write_text(file_contents)
+    file_path.write_text(file_contents)

--- a/src/mbed_tools/build/config.py
+++ b/src/mbed_tools/build/config.py
@@ -5,12 +5,15 @@
 """Parses the Mbed configuration system and generates a CMake config script."""
 import pathlib
 
+from typing import Any
+
 from mbed_tools.lib.json_helpers import decode_json_file
 from mbed_tools.project import MbedProgram
 from mbed_tools.targets import get_target_by_name
 from mbed_tools.build._internal.cmake_file import render_mbed_config_cmake_template
 from mbed_tools.build._internal.config.assemble_build_config import assemble_config
 from mbed_tools.build._internal.write_files import write_file
+from mbed_tools.build.exceptions import MbedBuildError
 
 
 def generate_config(target_name: str, toolchain: str, program: MbedProgram) -> pathlib.Path:
@@ -24,7 +27,8 @@ def generate_config(target_name: str, toolchain: str, program: MbedProgram) -> p
     Returns:
         Path to the generated config file.
     """
-    target_build_attributes = get_target_by_name(target_name, decode_json_file(program.mbed_os.targets_json_file))
+    targets_data = _load_raw_targets_data(program)
+    target_build_attributes = get_target_by_name(target_name, targets_data)
     config = assemble_config(target_build_attributes, program.root, program.files.app_config_file)
     cmake_file_contents = render_mbed_config_cmake_template(
         target_name=target_name, config=config, toolchain_name=toolchain,
@@ -32,3 +36,20 @@ def generate_config(target_name: str, toolchain: str, program: MbedProgram) -> p
     cmake_config_file_path = program.files.cmake_config_file
     write_file(cmake_config_file_path, cmake_file_contents)
     return cmake_config_file_path
+
+
+def _load_raw_targets_data(program: MbedProgram) -> Any:
+    targets_data = decode_json_file(program.mbed_os.targets_json_file)
+    if program.files.custom_targets_json.exists():
+        custom_targets_data = decode_json_file(program.files.custom_targets_json)
+        for custom_target in custom_targets_data:
+            if custom_target in targets_data:
+                raise MbedBuildError(
+                    f"Error found in {program.files.custom_targets_json}.\n"
+                    f"A target with the name '{custom_target}' already exists in targets.json. "
+                    "Please give your custom target a unique name so it can be identified."
+                )
+
+        targets_data.update(custom_targets_data)
+
+    return targets_data

--- a/src/mbed_tools/build/config.py
+++ b/src/mbed_tools/build/config.py
@@ -30,5 +30,5 @@ def generate_config(target_name: str, toolchain: str, program: MbedProgram) -> p
         target_name=target_name, config=config, toolchain_name=toolchain,
     )
     cmake_config_file_path = program.files.cmake_config_file
-    write_file(cmake_config_file_path.parent, cmake_config_file_path.name, cmake_file_contents)
+    write_file(cmake_config_file_path, cmake_file_contents)
     return cmake_config_file_path

--- a/src/mbed_tools/build/config.py
+++ b/src/mbed_tools/build/config.py
@@ -8,7 +8,7 @@ import pathlib
 from mbed_tools.lib.json_helpers import decode_json_file
 from mbed_tools.project import MbedProgram
 from mbed_tools.targets import get_target_by_name
-from mbed_tools.build._internal.cmake_file import generate_mbed_config_cmake_file
+from mbed_tools.build._internal.cmake_file import render_mbed_config_cmake_template
 from mbed_tools.build._internal.config.assemble_build_config import assemble_config
 from mbed_tools.build._internal.write_files import write_file
 
@@ -26,7 +26,9 @@ def generate_config(target_name: str, toolchain: str, program: MbedProgram) -> p
     """
     target_build_attributes = get_target_by_name(target_name, decode_json_file(program.mbed_os.targets_json_file))
     config = assemble_config(target_build_attributes, program.root, program.files.app_config_file)
-    cmake_file_contents = generate_mbed_config_cmake_file(target_name, config, toolchain)
+    cmake_file_contents = render_mbed_config_cmake_template(
+        target_name=target_name, config=config, toolchain_name=toolchain,
+    )
     cmake_config_file_path = program.files.cmake_config_file
     write_file(cmake_config_file_path.parent, cmake_config_file_path.name, cmake_file_contents)
     return cmake_config_file_path

--- a/src/mbed_tools/build/config.py
+++ b/src/mbed_tools/build/config.py
@@ -5,6 +5,7 @@
 """Parses the Mbed configuration system and generates a CMake config script."""
 import pathlib
 
+from mbed_tools.lib.json_helpers import decode_json_file
 from mbed_tools.project import MbedProgram
 from mbed_tools.targets import get_target_by_name
 from mbed_tools.build._internal.cmake_file import generate_mbed_config_cmake_file
@@ -23,7 +24,7 @@ def generate_config(target_name: str, toolchain: str, program: MbedProgram) -> p
     Returns:
         Path to the generated config file.
     """
-    target_build_attributes = get_target_by_name(target_name, program.mbed_os.targets_json_file)
+    target_build_attributes = get_target_by_name(target_name, decode_json_file(program.mbed_os.targets_json_file))
     config = assemble_config(target_build_attributes, program.root, program.files.app_config_file)
     cmake_file_contents = generate_mbed_config_cmake_file(target_name, config, toolchain)
     cmake_config_file_path = program.files.cmake_config_file

--- a/src/mbed_tools/cli/build.py
+++ b/src/mbed_tools/cli/build.py
@@ -35,6 +35,9 @@ from mbed_tools.sterm import terminal
     "--mbed-os-path", type=click.Path(), default=None, help="Path to local Mbed OS directory.",
 )
 @click.option(
+    "--custom-targets-json", type=click.Path(), default=None, help="Path to custom_targets.json.",
+)
+@click.option(
     "-f", "--flash", is_flag=True, default=False, help="Flash the binary onto a device",
 )
 @click.option(
@@ -60,6 +63,7 @@ def build(
     sterm: bool = False,
     baudrate: int = 9600,
     mbed_os_path: str = None,
+    custom_targets_json: str = None,
 ) -> None:
     """Configure and build an Mbed project using CMake and Ninja.
 
@@ -73,6 +77,7 @@ def build(
        program_path: Path to the Mbed project.
        mbed_os_path: the path to the local Mbed OS directory
        profile: The Mbed build profile (debug, develop or release).
+       custom_targets_json: Path to custom_targets.json.
        toolchain: The toolchain to use for the build.
        mbed_target: The name of the Mbed target to build for.
        clean: Perform a clean build.
@@ -93,6 +98,9 @@ def build(
     if any([not mbed_config_file.exists(), not build_tree.exists(), mbed_target, toolchain]):
         click.echo("Configuring project and generating build system...")
         _validate_target_and_toolchain_args(mbed_target, toolchain)
+        if custom_targets_json is not None:
+            program.files.custom_targets_json = pathlib.Path(custom_targets_json)
+
         generate_config(mbed_target.upper(), toolchain, program)
         generate_build_system(program.root, build_tree, profile)
 

--- a/src/mbed_tools/project/_internal/git_utils.py
+++ b/src/mbed_tools/project/_internal/git_utils.py
@@ -55,7 +55,8 @@ def checkout(repo: git.Repo, ref: str, force: bool = False) -> None:
         VersionControlError: Check out failed.
     """
     try:
-        repo.git.checkout(f"--force {ref}" if force else str(ref))
+        git_args = [ref] + ["--force"] if force else [ref]
+        repo.git.checkout(*git_args)
     except git.exc.GitCommandError as err:
         raise VersionControlError(f"Failed to check out revision '{ref}'. Error from VCS: {err}")
 

--- a/src/mbed_tools/project/_internal/project_data.py
+++ b/src/mbed_tools/project/_internal/project_data.py
@@ -27,6 +27,7 @@ MAIN_CPP_FILE_NAME = "main.cpp"
 MBED_OS_REFERENCE_FILE_NAME = "mbed-os.lib"
 MBED_OS_DIR_NAME = "mbed-os"
 TARGETS_JSON_FILE_PATH = Path("targets", "targets.json")
+CUSTOM_TARGETS_JSON_FILE_NAME = "custom_targets.json"
 
 # Information written to mbed-os.lib
 MBED_OS_REFERENCE_URL = "https://github.com/ARMmbed/mbed-os"
@@ -59,6 +60,7 @@ class MbedProgramFiles:
     cmakelists_file: Path
     cmake_config_file: Path
     cmake_build_dir: Path
+    custom_targets_json: Path
 
     @classmethod
     def from_new(cls, root_path: Path) -> "MbedProgramFiles":
@@ -79,6 +81,7 @@ class MbedProgramFiles:
         gitignore = root_path / ".gitignore"
         cmake_config = root_path / CMAKE_CONFIG_FILE_PATH
         cmake_build_dir = root_path / CMAKE_BUILD_DIR
+        custom_targets_json = root_path / CUSTOM_TARGETS_JSON_FILE_NAME
 
         if mbed_os_ref.exists():
             raise ValueError(f"Program already exists at path {root_path}.")
@@ -94,6 +97,7 @@ class MbedProgramFiles:
             cmakelists_file=cmakelists_file,
             cmake_config_file=cmake_config,
             cmake_build_dir=cmake_build_dir,
+            custom_targets_json=custom_targets_json,
         )
 
     @classmethod
@@ -109,6 +113,7 @@ class MbedProgramFiles:
             logger.info("This program does not contain an mbed_app.json config file.")
             app_config = None
 
+        custom_targets_json = root_path / CUSTOM_TARGETS_JSON_FILE_NAME
         mbed_os_file = root_path / MBED_OS_REFERENCE_FILE_NAME
 
         cmakelists_file = root_path / CMAKELISTS_FILE_NAME
@@ -121,6 +126,7 @@ class MbedProgramFiles:
             cmakelists_file=cmakelists_file,
             cmake_config_file=root_path / CMAKE_CONFIG_FILE_PATH,
             cmake_build_dir=root_path / CMAKE_BUILD_DIR,
+            custom_targets_json=custom_targets_json,
         )
 
 

--- a/src/mbed_tools/project/_internal/templates/CMakeLists.tmpl
+++ b/src/mbed_tools/project/_internal/templates/CMakeLists.tmpl
@@ -17,8 +17,6 @@ add_executable(${APP_TARGET}
 
 mbed_configure_app_target(${APP_TARGET})
 
-mbed_set_mbed_target_linker_script(${APP_TARGET})
-
 project(${APP_TARGET})
 
 target_link_libraries(${APP_TARGET} mbed-os)

--- a/src/mbed_tools/targets/_internal/target_attributes.py
+++ b/src/mbed_tools/targets/_internal/target_attributes.py
@@ -7,12 +7,11 @@
 This information is parsed from the targets.json configuration file
 found in the mbed-os repo.
 """
-import json
 import pathlib
-from json.decoder import JSONDecodeError
-from typing import Dict, Any, Set, Optional, cast
+from typing import Dict, Any, Set, Optional
 
 from mbed_tools.lib.exceptions import ToolsError
+from mbed_tools.lib.json_helpers import decode_json_file
 
 from mbed_tools.targets._internal.targets_json_parsers.accumulating_attribute_parser import (
     get_accumulating_attributes_for_target,
@@ -39,25 +38,22 @@ class TargetNotFoundError(TargetAttributesError):
     """Target definition not found in targets.json."""
 
 
-def get_target_attributes(path_to_targets_json: pathlib.Path, target_name: str) -> dict:
+def get_target_attributes(targets_json_data: dict, target_name: str) -> dict:
     """Retrieves attribute data taken from targets.json for a single target.
 
     Args:
-        path_to_targets_json: an absolute or relative path to the location of targets.json.
+        targets_json_data: target definitions from targets.json
         target_name: the name of the target (often a Board's board_type).
 
     Returns:
         A dictionary representation of the attributes for the target.
 
     Raises:
-        FileNotFoundError: path provided does not lead to targets.json
         ParsingTargetJSONError: error parsing targets.json
         TargetNotFoundError: there is no target attribute data found for that target.
     """
-    targets_json_path = path_to_targets_json
-    all_targets_data = _read_json_file(targets_json_path)
-    target_attributes = _extract_target_attributes(all_targets_data, target_name)
-    target_attributes["labels"] = get_labels_for_target(all_targets_data, target_name).union(
+    target_attributes = _extract_target_attributes(targets_json_data, target_name)
+    target_attributes["labels"] = get_labels_for_target(targets_json_data, target_name).union(
         _extract_core_labels(target_attributes.get("core", None))
     )
     target_attributes["extra_labels"] = set(target_attributes.get("extra_labels", []))
@@ -68,26 +64,6 @@ def get_target_attributes(path_to_targets_json: pathlib.Path, target_name: str) 
         target_attributes.get("config", {}), target_attributes.get("overrides", {})
     )
     return target_attributes
-
-
-def _read_json_file(path_to_file: pathlib.Path) -> dict:
-    """Reads the data from a json file.
-
-    Args:
-        path_to_file: location of the json file.
-
-    Returns:
-        A dictionary representation of all the data in the json file.
-
-    Raises:
-        ParsingTargetJSONError: error parsing targets.json
-        FileNotFoundError: path provided does not lead to a valid json file
-    """
-    try:
-        # mypy doesn't recognise that json.loads always returns a dictionary
-        return cast(dict, json.loads(path_to_file.read_text()))
-    except JSONDecodeError as json_err:
-        raise ParsingTargetsJSONError(f"Invalid JSON found in '{path_to_file}'.") from json_err
 
 
 def _extract_target_attributes(all_targets_data: Dict[str, Any], target_name: str) -> dict:
@@ -127,7 +103,7 @@ def _extract_core_labels(target_core: Optional[str]) -> Set[str]:
         if either core is undefined or no labels found for the core.
     """
     if target_core:
-        mbed_os_metadata = _read_json_file(MBED_OS_METADATA_FILE)
+        mbed_os_metadata = decode_json_file(MBED_OS_METADATA_FILE)
         return set(mbed_os_metadata["CORE_LABELS"].get(target_core, []))
     return set()
 

--- a/src/mbed_tools/targets/get_target.py
+++ b/src/mbed_tools/targets/get_target.py
@@ -7,40 +7,38 @@
 An instance of `mbed_tools.targets.target.Target`
 can be retrieved by calling one of the public functions.
 """
-import pathlib
-
 from mbed_tools.targets.exceptions import TargetError
 from mbed_tools.targets._internal import target_attributes
 
 
-def get_target_by_name(name: str, path_to_targets_json: pathlib.Path) -> dict:
+def get_target_by_name(name: str, targets_json_data: dict) -> dict:
     """Returns a dictionary of attributes for the target whose name matches the name given.
 
     The target is as defined in the targets.json file found in the Mbed OS library.
 
     Args:
         name: the name of the Target to be returned
-        path_to_targets_json: path to a targets.json file containing target definitions
+        targets_json_data: target definitions from targets.json
 
     Raises:
         TargetError: an error has occurred while fetching target
     """
     try:
-        return target_attributes.get_target_attributes(path_to_targets_json, name)
+        return target_attributes.get_target_attributes(targets_json_data, name)
     except (FileNotFoundError, target_attributes.TargetAttributesError) as e:
         raise TargetError(e) from e
 
 
-def get_target_by_board_type(board_type: str, path_to_targets_json: pathlib.Path) -> dict:
+def get_target_by_board_type(board_type: str, targets_json_data: dict) -> dict:
     """Returns the target whose name matches a board's build_type.
 
     The target is as defined in the targets.json file found in the Mbed OS library.
 
     Args:
         board_type: a board's board_type (see `mbed_tools.targets.board.Board`)
-        path_to_targets_json: path to a targets.json file containing target definitions
+        targets_json_data: target definitions from targets.json
 
     Raises:
         TargetError: an error has occurred while fetching target
     """
-    return get_target_by_name(board_type, path_to_targets_json)
+    return get_target_by_name(board_type, targets_json_data)

--- a/tests/build/_internal/test_cmake_file.py
+++ b/tests/build/_internal/test_cmake_file.py
@@ -4,7 +4,7 @@
 #
 import pytest
 
-from mbed_tools.build._internal.cmake_file import generate_mbed_config_cmake_file, _render_mbed_config_cmake_template
+from mbed_tools.build._internal.cmake_file import render_mbed_config_cmake_template
 from mbed_tools.build._internal.config.config import Config
 from mbed_tools.build._internal.config.source import ConfigSetting, prepare
 
@@ -30,20 +30,10 @@ def fake_target():
     }
 
 
-class TestGenerateCMakeListsFile:
-    def test_correct_arguments_passed(self, fake_target):
-        config = Config(prepare(fake_target))
-        mbed_target = "K64F"
-
-        result = generate_mbed_config_cmake_file(mbed_target, config, TOOLCHAIN_NAME)
-
-        assert result == _render_mbed_config_cmake_template(Config(prepare(fake_target)), TOOLCHAIN_NAME, mbed_target,)
-
-
 class TestRendersCMakeListsFile:
     def test_returns_rendered_content(self, fake_target):
         config = Config(prepare(fake_target))
-        result = _render_mbed_config_cmake_template(config, TOOLCHAIN_NAME, "target_name")
+        result = render_mbed_config_cmake_template(config, TOOLCHAIN_NAME, "target_name")
 
         for label in fake_target["labels"] + fake_target["extra_labels"]:
             assert label in result
@@ -69,5 +59,5 @@ class TestRendersCMakeListsFile:
             )
         ]
 
-        result = _render_mbed_config_cmake_template(config, TOOLCHAIN_NAME, "target_name")
+        result = render_mbed_config_cmake_template(config, TOOLCHAIN_NAME, "target_name")
         assert '"-DMBED_CONF_IOTC_MQTT_HOST={\\"mqtt.2030.ltsapis.goog\\", IOTC_MQTT_PORT}"' in result

--- a/tests/build/_internal/test_write_files.py
+++ b/tests/build/_internal/test_write_files.py
@@ -14,17 +14,16 @@ class TestWriteFile(TestCase):
     def test_writes_content_to_file(self):
         with tempfile.TemporaryDirectory() as directory:
             content = "Some rendered content"
-            export_path = pathlib.Path(directory, "output")
-            file_name = "some_file.txt"
+            export_path = pathlib.Path(directory, "output", "some_file.txt")
 
-            write_file(export_path, file_name, content)
+            write_file(export_path, content)
 
-            created_file = pathlib.Path(export_path, pathlib.Path(export_path, file_name))
+            created_file = pathlib.Path(export_path)
             self.assertEqual(created_file.read_text(), content)
 
     def test_output_dir_is_file(self):
         with tempfile.TemporaryDirectory() as directory:
-            bad_export_dir = pathlib.Path(directory, "some_file.txt")
-            bad_export_dir.touch()
+            bad_export_dir = pathlib.Path(directory, "some_file.txt", ".txt")
+            bad_export_dir.parent.touch()
             with self.assertRaises(InvalidExportOutputDirectory):
-                write_file(bad_export_dir, "any_file.txt", "some contents")
+                write_file(bad_export_dir, "some contents")

--- a/tests/build/test_generate_config.py
+++ b/tests/build/test_generate_config.py
@@ -90,6 +90,27 @@ def test_target_and_toolchain_collected(program):
     assert toolchain in config_text
 
 
+def test_custom_targets_data_found(program):
+    program.files.custom_targets_json.write_text(json.dumps({"IMAGINARYBOARD": TARGET_DATA}))
+    target = "IMAGINARYBOARD"
+    toolchain = "GCC_ARM"
+
+    generate_config(target, toolchain, program)
+
+    config_text = program.files.cmake_config_file.read_text()
+
+    assert target in config_text
+
+
+def test_raises_error_when_attempting_to_customize_existing_target(program):
+    program.files.custom_targets_json.write_text(json.dumps({TARGETS[0]: TARGET_DATA}))
+    target = TARGETS[0]
+    toolchain = "GCC_ARM"
+
+    with pytest.raises(ToolsError):
+        generate_config(target, toolchain, program)
+
+
 def test_config_param_from_lib_processed_with_default_name_mangling(program):
     create_mbed_lib_json(
         program.mbed_os.root / "platform" / "mbed_lib.json",

--- a/tests/cli/test_build.py
+++ b/tests/cli/test_build.py
@@ -144,6 +144,21 @@ class TestBuildCommand(TestCase):
             generate_config.assert_called_once_with(target.upper(), toolchain.upper(), program)
             generate_build_system.assert_called_once_with(program.root, program.files.cmake_build_dir, "develop")
 
+    def test_custom_targets_location_used_when_passed(
+        self, generate_config, mbed_program, build_project, generate_build_system
+    ):
+        program = mbed_program.from_existing()
+        with mock_project_directory(program, mbed_config_exists=True, build_tree_exists=True):
+            toolchain = "gcc_arm"
+            target = "k64f"
+            custom_targets_json_path = pathlib.Path("custom", "custom_targets.json")
+
+            runner = CliRunner()
+            runner.invoke(build, ["-t", toolchain, "-m", target, "--custom-targets-json", custom_targets_json_path])
+
+            generate_config.assert_called_once_with(target.upper(), toolchain.upper(), program)
+            self.assertEqual(program.files.custom_targets_json, custom_targets_json_path)
+
     def test_build_folder_removed_when_clean_flag_passed(
         self, generate_config, mbed_program, build_project, generate_build_system
     ):

--- a/tests/project/_internal/test_git_utils.py
+++ b/tests/project/_internal/test_git_utils.py
@@ -84,9 +84,14 @@ class TestGetRepo:
 
 class TestCheckout:
     def test_git_lib_called_with_correct_command(self, mock_repo):
+        git_utils.checkout(mock_repo, "master")
+
+        mock_repo.git.checkout.assert_called_once_with("master")
+
+    def test_git_lib_called_with_correct_command_with_force(self, mock_repo):
         git_utils.checkout(mock_repo, "master", force=True)
 
-        mock_repo.git.checkout.assert_called_once_with("--force master")
+        mock_repo.git.checkout.assert_called_once_with("master", "--force")
 
     def test_raises_version_control_error_when_git_checkout_fails(self, mock_repo):
         mock_repo.git.checkout.side_effect = git_utils.git.exc.GitCommandError("git checkout", 255)

--- a/travis-ci/test-data/TARGET_IMAGINARYBOARD/CMakeLists.txt
+++ b/travis-ci/test-data/TARGET_IMAGINARYBOARD/CMakeLists.txt
@@ -1,0 +1,16 @@
+# Copyright (c) 2020-2021 Arm Limited and Contributors. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+add_library(IMAGINARYBOARD INTERFACE)
+
+target_sources(IMAGINARYBOARD
+    INTERFACE
+        PeripheralPins.c
+)
+
+target_include_directories(IMAGINARYBOARD
+    INTERFACE
+        .
+)
+
+target_link_libraries(IMAGINARYBOARD INTERFACE STM32L475xG)

--- a/travis-ci/test-data/custom_targets.json
+++ b/travis-ci/test-data/custom_targets.json
@@ -1,0 +1,28 @@
+{
+    "IMAGINARYBOARD": {
+        "inherits": [
+            "MCU_STM32L475xG"
+        ],
+        "components_add": [
+            "BlueNRG_MS",
+            "QSPIF"
+        ],
+        "extra_labels_add": [
+            "CORDIO",
+            "MX25R6435F"
+        ],
+        "supported_form_factors": [
+            "ARDUINO"
+        ],
+        "detect_code": [
+            "1234"
+        ],
+        "device_has_add": [
+            "QSPI"
+        ],
+        "features": [
+            "BLE"
+        ],
+        "device_name": "STM32L475VG"
+    }
+}


### PR DESCRIPTION
### Description
Adds support for custom_targets.json in the tools.

This is dependent on [mbed-os CMake changes](https://github.com/ARMmbed/mbed-os/pull/14199). 
Without those changes adding a custom target using `add_subdirectory` will make mbed-os fail to  build for standard mbed targets.

With those changes (once applied to all targets) you can add your target using  `add_subdirectory(<target-dir> EXCLUDE_FROM_ALL)` before adding the mbed-os subdirectory, in the top level CMakeLists.txt, and the custom target will integrate into the build system without breaking it.

While I'm here fix the `deploy --force` option as that was broken.

<!--
Please add any detail or context that would be useful to a reviewer.
-->



### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [x]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
