### PR TITLE
ci: Remove Python3.7 from test matrix

### DIFF
--- a/azure-pipelines/analyse-and-test.yml
+++ b/azure-pipelines/analyse-and-test.yml
@@ -31,12 +31,6 @@ stages:
               uploadCoverage: "false"
               tox.env: linting
 
-            Linting_Py_3_7:
-              python.version: '3.7'
-              vmImageName: ubuntu-latest
-              uploadCoverage: "false"
-              tox.env: linting
-
             Linting_Py_3_8:
               python.version: '3.8'
               vmImageName: ubuntu-latest
@@ -54,12 +48,6 @@ stages:
               vmImageName: ubuntu-latest
               uploadCoverage: "false"
               tox.env: py36
-
-            Linux_Py_3_7:
-              python.version: '3.7'
-              vmImageName: ubuntu-latest
-              uploadCoverage: "false"
-              tox.env: py37
 
             Linux_Py_3_8:
               python.version: '3.8'
@@ -79,12 +67,6 @@ stages:
               uploadCoverage: "false"
               tox.env: py36
 
-            Windows_Py_3_7:
-              python.version: '3.7'
-              vmImageName: windows-latest
-              uploadCoverage: "false"
-              tox.env: py37
-
             Windows_Py_3_8:
               python.version: '3.8'
               vmImageName: windows-latest
@@ -102,12 +84,6 @@ stages:
               vmImageName: macOS-latest
               uploadCoverage: "false"
               tox.env: py36
-
-            macOS_Py_3_7:
-              python.version: '3.7'
-              vmImageName: macOS-latest
-              uploadCoverage: "false"
-              tox.env: py37
 
             macOS_Py_3_8:
               python.version: '3.8'

--- a/news/20210113.misc
+++ b/news/20210113.misc
@@ -1,0 +1,1 @@
+Remove Python 3.7 testing from Tox and CI.

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = dev,linting,checknews,py36,py37,py38,py39
+envlist = dev,linting,checknews,py36,py38,py39
 minversion = 3.3.0
 # Activate isolated build environment. tox will use a virtual environment
 # to build a source distribution from the source tree.


### PR DESCRIPTION
### Description

Remove Python 3.7 testing in Tox and CI as it is no longer considered a primary configuration.

Fixes #165 
### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [x]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
