### PR TITLE
travis: Build lorawan example for DISCO_L072CZ_LRWAN1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -128,8 +128,8 @@ matrix:
       env: EXAMPLE_NAME=mbed-os-example-devicekey TARGET_NAME=K66F CACHE_NAME=devicekey-K66F
 
     - <<: *mbed-tools-test
-      name: "Test lorawan example (K66F)"
-      env: EXAMPLE_NAME=mbed-os-example-lorawan TARGET_NAME=K66F CACHE_NAME=lorawan-K66F
+      name: "Test lorawan example (DISCO_L072CZ_LRWAN1)"
+      env: EXAMPLE_NAME=mbed-os-example-lorawan TARGET_NAME=DISCO_L072CZ_LRWAN1 CACHE_NAME=lorawan-DISCO_L072CZ_LRWAN1
 
     - <<: *mbed-tools-test
       name: "Test crypto example (K64F)"

--- a/news/20210119095356.misc
+++ b/news/20210119095356.misc
@@ -1,0 +1,1 @@
+Build lorawan example for DISCO_L072CZ_LRWAN1


### PR DESCRIPTION

### Description

The mbed-os-example-lorawan example removed support for building with
targets that don't have radio connections specified in the example's
mbed_app.json. This means we can no longer build the example for the
K66F target. Build for the DISCO_L072CZ_LRWAN1 target instead.




### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [X]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
