### PR TITLE
compile: Update command line option

### DIFF
--- a/news/20210121143556.major
+++ b/news/20210121143556.major
@@ -1,0 +1,1 @@
+Compile: change command line option --build-type to --profile

--- a/src/mbed_tools/cli/build.py
+++ b/src/mbed_tools/cli/build.py
@@ -23,7 +23,7 @@ from mbed_tools.sterm import terminal
     help="The toolchain you are using to build your app.",
 )
 @click.option("-m", "--mbed-target", help="A build target for an Mbed-enabled device, e.g. K64F.")
-@click.option("-b", "--build-type", default="develop", help="The build type (release, develop or debug).")
+@click.option("-b", "--profile", default="develop", help="The build type (release, develop or debug).")
 @click.option("-c", "--clean", is_flag=True, default=False, help="Perform a clean build.")
 @click.option(
     "-p",
@@ -51,7 +51,7 @@ from mbed_tools.sterm import terminal
 )
 def build(
     program_path: str,
-    build_type: str,
+    profile: str,
     toolchain: str = "",
     mbed_target: str = "",
     clean: bool = False,
@@ -72,7 +72,7 @@ def build(
     Args:
        program_path: Path to the Mbed project.
        mbed_os_path: the path to the local Mbed OS directory
-       build_type: The Mbed build profile (debug, develop or release).
+       profile: The Mbed build profile (debug, develop or release).
        toolchain: The toolchain to use for the build.
        mbed_target: The name of the Mbed target to build for.
        clean: Perform a clean build.
@@ -94,7 +94,7 @@ def build(
         click.echo("Configuring project and generating build system...")
         _validate_target_and_toolchain_args(mbed_target, toolchain)
         generate_config(mbed_target.upper(), toolchain, program)
-        generate_build_system(program.root, build_tree, build_type)
+        generate_build_system(program.root, build_tree, profile)
 
     click.echo("Building Mbed project...")
     build_project(build_tree)


### PR DESCRIPTION
### Description

<!--
Please add any detail or context that would be useful to a reviewer.
-->

In Mbed CLI 1, `--profile` was used to identify type of build. Change
`--build-type` to `--profile` to match Mbed CLI 1 behaviour.

### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [x]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
