### PR TITLE
README: Remove dead link to license report

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@
 [![PyPI - Python Version](https://img.shields.io/pypi/pyversions/mbed-tools)](https://pypi.org/project/mbed-tools/)
 
 [![License](https://badgen.net/pypi/license/mbed-tools)](https://github.com/ARMmbed/mbed-tools/blob/master/LICENSE)
-[![Compliance](https://badgen.net/badge/License%20Report/compliant/green?icon=libraries)](https://armmbed.github.io/mbed-tools/api/third_party_IP_report.html)
 
 [![Build Status](https://dev.azure.com/mbed-tools/mbed-tools/_apis/build/status/Build%20and%20Release?branchName=master&stageName=CI%20Checkpoint)](https://dev.azure.com/mbed-tools/mbed-tools/_build/latest?definitionId=10&branchName=master)
 [![Test Coverage](https://codecov.io/gh/ARMmbed/mbed-tools/branch/master/graph/badge.svg)](https://codecov.io/gh/ARMmbed/mbed-tools)

--- a/news/20210127150731.misc
+++ b/news/20210127150731.misc
@@ -1,0 +1,1 @@
+Remove dead license report link from README


### PR DESCRIPTION
### Description

The license report link was dead (404). Remove the badge and link to the
license compliance report.

### Test Coverage

- [ ]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [X]  Additional tests are not required for this change (e.g. documentation update).
