### PR TITLE
targets: Add Cortex-M55 definitions

### DIFF
--- a/news/20210127171548.feature
+++ b/news/20210127171548.feature
@@ -1,0 +1,1 @@
+Add Cortex-M55 target definitions

--- a/src/mbed_tools/targets/_internal/data/targets_metadata.json
+++ b/src/mbed_tools/targets/_internal/data/targets_metadata.json
@@ -116,6 +116,45 @@
             "CORTEX_M",
             "LIKE_CORTEX_M33",
             "CORTEX"
+        ],
+        "Cortex-M55": [
+            "M55",
+            "CORTEX_M",
+            "LIKE_CORTEX_M55",
+            "CORTEX"
+        ],
+        "Cortex-M55-NS": [
+            "M55",
+            "M55_NS",
+            "CORTEX_M",
+            "LIKE_CORTEX_M55",
+            "CORTEX"
+        ],
+        "Cortex-M55F": [
+            "M55",
+            "CORTEX_M",
+            "LIKE_CORTEX_M55",
+            "CORTEX"
+        ],
+        "Cortex-M55F-NS": [
+            "M55",
+            "M55_NS",
+            "CORTEX_M",
+            "LIKE_CORTEX_M55",
+            "CORTEX"
+        ],
+        "Cortex-M55FE": [
+            "M55",
+            "CORTEX_M",
+            "LIKE_CORTEX_M55",
+            "CORTEX"
+        ],
+        "Cortex-M55FE-NS": [
+            "M55",
+            "M55_NS",
+            "CORTEX_M",
+            "LIKE_CORTEX_M55",
+            "CORTEX"
         ]
     }
 }


### PR DESCRIPTION
### Description

Add Cortex-M55 definitions

### Test Coverage

Nothing to test here, as no new targets in Mbed OS have been added yet. We may need to fix bugs in this addition when trouble pops up with adding the new Mbed OS targets.

- [ ]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
