### PR TITLE
Add build subdirectories for multiple targets/toolchains

### DIFF
--- a/news/141.feature
+++ b/news/141.feature
@@ -1,0 +1,1 @@
+Builds are now separated by target, profile and toolchain, allowing use of different configurations without clearing previous builds.

--- a/news/20210203124012.major
+++ b/news/20210203124012.major
@@ -1,0 +1,1 @@
+The compile subcommand now requires both toolchain and mbed-target arguments.

--- a/src/mbed_tools/cli/build.py
+++ b/src/mbed_tools/cli/build.py
@@ -87,10 +87,11 @@ def build(
        baudrate: Change the serial baud rate (ignored unless --sterm is also given).
     """
     _validate_target_and_toolchain_args(mbed_target, toolchain)
+    cmake_build_subdir = pathlib.Path(mbed_target.upper(), profile.lower(), toolchain.upper())
     if mbed_os_path is None:
-        program = MbedProgram.from_existing(pathlib.Path(program_path))
+        program = MbedProgram.from_existing(pathlib.Path(program_path), cmake_build_subdir)
     else:
-        program = MbedProgram.from_existing(pathlib.Path(program_path), pathlib.Path(mbed_os_path))
+        program = MbedProgram.from_existing(pathlib.Path(program_path), cmake_build_subdir, pathlib.Path(mbed_os_path))
     build_tree = program.files.cmake_build_dir
     if clean and build_tree.exists():
         shutil.rmtree(build_tree)

--- a/src/mbed_tools/cli/build.py
+++ b/src/mbed_tools/cli/build.py
@@ -91,23 +91,15 @@ def build(
         program = MbedProgram.from_existing(pathlib.Path(program_path))
     else:
         program = MbedProgram.from_existing(pathlib.Path(program_path), pathlib.Path(mbed_os_path))
-    mbed_config_file = program.files.cmake_config_file
     build_tree = program.files.cmake_build_dir
     if clean and build_tree.exists():
         shutil.rmtree(build_tree)
-    if any(
-        [
-            not mbed_config_file.exists(),
-            not build_tree.exists(),
-            mbed_os_path is not None,
-            custom_targets_json is not None,
-        ]
-    ):
-        click.echo("Configuring project and generating build system...")
-        if custom_targets_json is not None:
-            program.files.custom_targets_json = pathlib.Path(custom_targets_json)
-        generate_config(mbed_target.upper(), toolchain, program)
-        generate_build_system(program.root, build_tree, profile)
+
+    click.echo("Configuring project and generating build system...")
+    if custom_targets_json is not None:
+        program.files.custom_targets_json = pathlib.Path(custom_targets_json)
+    generate_config(mbed_target.upper(), toolchain, program)
+    generate_build_system(program.root, build_tree, profile)
 
     click.echo("Building Mbed project...")
     build_project(build_tree)

--- a/src/mbed_tools/cli/build.py
+++ b/src/mbed_tools/cli/build.py
@@ -75,7 +75,7 @@ def build(
 
     Args:
        program_path: Path to the Mbed project.
-       mbed_os_path: the path to the local Mbed OS directory
+       mbed_os_path: The path to the local Mbed OS directory.
        profile: The Mbed build profile (debug, develop or release).
        custom_targets_json: Path to custom_targets.json.
        toolchain: The toolchain to use for the build.

--- a/src/mbed_tools/cli/configure.py
+++ b/src/mbed_tools/cli/configure.py
@@ -48,10 +48,11 @@ def configure(toolchain: str, mbed_target: str, program_path: str, mbed_os_path:
         program_path: the path to the local Mbed program
         mbed_os_path: the path to the local Mbed OS directory
     """
+    cmake_build_subdir = pathlib.Path(mbed_target.upper(), "develop", toolchain.upper())
     if mbed_os_path is None:
-        program = MbedProgram.from_existing(pathlib.Path(program_path))
+        program = MbedProgram.from_existing(pathlib.Path(program_path), cmake_build_subdir)
     else:
-        program = MbedProgram.from_existing(pathlib.Path(program_path), pathlib.Path(mbed_os_path))
+        program = MbedProgram.from_existing(pathlib.Path(program_path), cmake_build_subdir, pathlib.Path(mbed_os_path))
     mbed_target = mbed_target.upper()
     output_path = generate_config(mbed_target, toolchain, program)
     click.echo(f"mbed_config.cmake has been generated and written to '{str(output_path.resolve())}'")

--- a/src/mbed_tools/project/_internal/project_data.py
+++ b/src/mbed_tools/project/_internal/project_data.py
@@ -20,8 +20,8 @@ logger = logging.getLogger(__name__)
 
 # Mbed program file names and constants.
 APP_CONFIG_FILE_NAME = "mbed_app.json"
+BUILD_DIR = "cmake_build"
 CMAKE_CONFIG_FILE_PATH = Path(".mbedbuild", "mbed_config.cmake")
-CMAKE_BUILD_DIR = "cmake_build"
 CMAKELISTS_FILE_NAME = "CMakeLists.txt"
 MAIN_CPP_FILE_NAME = "main.cpp"
 MBED_OS_REFERENCE_FILE_NAME = "mbed-os.lib"
@@ -80,7 +80,7 @@ class MbedProgramFiles:
         main_cpp = root_path / MAIN_CPP_FILE_NAME
         gitignore = root_path / ".gitignore"
         cmake_config = root_path / CMAKE_CONFIG_FILE_PATH
-        cmake_build_dir = root_path / CMAKE_BUILD_DIR
+        cmake_build_dir = root_path / BUILD_DIR
         custom_targets_json = root_path / CUSTOM_TARGETS_JSON_FILE_NAME
 
         if mbed_os_ref.exists():
@@ -101,11 +101,12 @@ class MbedProgramFiles:
         )
 
     @classmethod
-    def from_existing(cls, root_path: Path) -> "MbedProgramFiles":
+    def from_existing(cls, root_path: Path, build_subdir: Path) -> "MbedProgramFiles":
         """Create MbedProgramFiles from a directory containing an existing program.
 
         Args:
             root_path: The path containing the MbedProgramFiles.
+            build_subdir: The subdirectory of BUILD_DIR to use for CMake build.
         """
         app_config: Optional[Path]
         app_config = root_path / APP_CONFIG_FILE_NAME
@@ -119,13 +120,14 @@ class MbedProgramFiles:
         cmakelists_file = root_path / CMAKELISTS_FILE_NAME
         if not cmakelists_file.exists():
             logger.warning("No CMakeLists.txt found in the program root.")
+        cmake_build_dir = root_path / BUILD_DIR / build_subdir
 
         return cls(
             app_config_file=app_config,
             mbed_os_ref=mbed_os_file,
             cmakelists_file=cmakelists_file,
             cmake_config_file=root_path / CMAKE_CONFIG_FILE_PATH,
-            cmake_build_dir=root_path / CMAKE_BUILD_DIR,
+            cmake_build_dir=cmake_build_dir,
             custom_targets_json=custom_targets_json,
         )
 

--- a/src/mbed_tools/project/mbed_program.py
+++ b/src/mbed_tools/project/mbed_program.py
@@ -71,7 +71,7 @@ class MbedProgram:
 
         Args:
             dir_path: Directory containing an Mbed program.
-            mbed_os_path: Directory containing Mbed OS
+            mbed_os_path: Directory containing Mbed OS.
             check_mbed_os: If True causes an exception to be raised if the Mbed OS source directory does not
                            exist.
 

--- a/src/mbed_tools/project/mbed_program.py
+++ b/src/mbed_tools/project/mbed_program.py
@@ -66,11 +66,14 @@ class MbedProgram:
         return cls(program_files, mbed_os)
 
     @classmethod
-    def from_existing(cls, dir_path: Path, mbed_os_path: Path = None, check_mbed_os: bool = True) -> "MbedProgram":
+    def from_existing(
+        cls, dir_path: Path, build_subdir: Path, mbed_os_path: Path = None, check_mbed_os: bool = True,
+    ) -> "MbedProgram":
         """Create an MbedProgram from an existing program directory.
 
         Args:
             dir_path: Directory containing an Mbed program.
+            build_subdir: The subdirectory for the CMake build tree.
             mbed_os_path: Directory containing Mbed OS.
             check_mbed_os: If True causes an exception to be raised if the Mbed OS source directory does not
                            exist.
@@ -85,7 +88,7 @@ class MbedProgram:
             program_root = dir_path
 
         logger.info(f"Found existing Mbed program at path '{program_root}'")
-        program = MbedProgramFiles.from_existing(program_root)
+        program = MbedProgramFiles.from_existing(program_root, build_subdir)
 
         try:
             mbed_os = MbedOS.from_existing(mbed_os_path, check_mbed_os)

--- a/tests/cli/test_build.py
+++ b/tests/cli/test_build.py
@@ -69,16 +69,6 @@ class TestBuildCommand(TestCase):
 
             generate_build_system.assert_called_once_with(program.root, program.files.cmake_build_dir, "develop")
 
-    def test_generate_build_system_not_called_if_build_tree_exists(
-        self, generate_config, mbed_program, build_project, generate_build_system
-    ):
-        program = mbed_program.from_existing()
-        with mock_project_directory(program, mbed_config_exists=True, build_tree_exists=True):
-            runner = CliRunner()
-            runner.invoke(build, DEFAULT_BUILD_ARGS)
-
-            generate_build_system.assert_not_called()
-
     def test_generate_config_called_if_config_script_nonexistent(
         self, generate_config, mbed_program, build_project, generate_build_system
     ):

--- a/tests/project/_internal/test_project_data.py
+++ b/tests/project/_internal/test_project_data.py
@@ -58,7 +58,7 @@ class TestMbedProgramFiles(TestCase):
         root = pathlib.Path(fs, "foo")
         make_mbed_program_files(root)
 
-        program = MbedProgramFiles.from_existing(root)
+        program = MbedProgramFiles.from_existing(root, pathlib.Path("K64F", "develop", "GCC_ARM"))
 
         self.assertTrue(program.app_config_file.exists())
         self.assertTrue(program.mbed_os_ref.exists())


### PR DESCRIPTION
### Description

Creates new subdirectories in cmake_build for each target/profile/toolchain combination, and writes build tree into these. This will be in `cmake_build/TARGET/PROFILE/TOOLCHAIN`

With these changes multiple target-toolchain combinations can be compiled for without manually moving files or clearing parts of the build tree each time. To ensure clarity with use of multiple targets and toolchains, both will be made to be required arguments for `compile`.

Fixes #141

### Test Coverage

- [x]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
