### PR TITLE
Support unhashable list of target.json

### DIFF
--- a/news/182.bugfix
+++ b/news/182.bugfix
@@ -1,0 +1,1 @@
+Support compilation of targets with sector attributes in targets.json.

--- a/src/mbed_tools/build/_internal/config/source.py
+++ b/src/mbed_tools/build/_internal/config/source.py
@@ -44,8 +44,10 @@ def prepare(
     namespace = data.pop("name", source_name)
     for key in data:
         if isinstance(data[key], list):
-            data[key] = set(data[key])
-
+            try:
+                data[key] = set(data[key])
+            except TypeError:
+                data[key] = set(*data[key])
     if "config" in data:
         data["config"] = _extract_config_settings(namespace, data["config"])
 

--- a/tests/build/_internal/config/test_source.py
+++ b/tests/build/_internal/config/test_source.py
@@ -109,8 +109,10 @@ class TestPrepareSource:
         lib = {
             "name": "library",
             "config": {"list-values": {"value": ["ETHERNET", "WIFI"]}},
+            "sectors": [[0, 2048]],
         }
 
         conf = source.prepare(lib)
 
         assert conf["config"][0].value == {"ETHERNET", "WIFI"}
+        assert conf["sectors"] == {0, 2048}


### PR DESCRIPTION
### Description

<!--
Please add any detail or context that would be useful to a reviewer.
-->
This PR could support unhashable list of Mbed target.json .
Most list in target.json are string type and could be a set type of python.
However, some targets add integer list, like as:       
```
"sectors": [
            [
                0,
                2048
            ]

```

This kind type will encounter `TypeError: unhashable type: 'list'` in `source.py` for config preparation.

### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [x]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
