### PR TITLE
config: move mbed config cmake `mbed_config.cmake` file from root to build directory

### DIFF
--- a/news/20210210161209.major
+++ b/news/20210210161209.major
@@ -1,0 +1,1 @@
+config: move mbed config cmake `mbed_config.cmake` file from root to build directory.

--- a/src/mbed_tools/build/config.py
+++ b/src/mbed_tools/build/config.py
@@ -15,6 +15,8 @@ from mbed_tools.build._internal.config.assemble_build_config import assemble_con
 from mbed_tools.build._internal.write_files import write_file
 from mbed_tools.build.exceptions import MbedBuildError
 
+CMAKE_CONFIG_FILE = "mbed_config.cmake"
+
 
 def generate_config(target_name: str, toolchain: str, program: MbedProgram) -> pathlib.Path:
     """Generate an Mbed config file at the program root by parsing the mbed config system.
@@ -33,7 +35,7 @@ def generate_config(target_name: str, toolchain: str, program: MbedProgram) -> p
     cmake_file_contents = render_mbed_config_cmake_template(
         target_name=target_name, config=config, toolchain_name=toolchain,
     )
-    cmake_config_file_path = program.files.cmake_config_file
+    cmake_config_file_path = program.files.cmake_build_dir / CMAKE_CONFIG_FILE
     write_file(cmake_config_file_path, cmake_file_contents)
     return cmake_config_file_path
 

--- a/src/mbed_tools/cli/build.py
+++ b/src/mbed_tools/cli/build.py
@@ -67,9 +67,6 @@ def build(
 ) -> None:
     """Configure and build an Mbed project using CMake and Ninja.
 
-    If the project has already been configured and contains '.mbedbuild/mbed_config.cmake', this command will skip the
-    Mbed configuration step and invoke CMake.
-
     If the CMake configuration step has already been run previously (i.e a CMake build tree exists), then just try to
     build the project immediately using Ninja.
 

--- a/src/mbed_tools/cli/configure.py
+++ b/src/mbed_tools/cli/configure.py
@@ -33,7 +33,7 @@ from mbed_tools.build import generate_config
     "--mbed-os-path", type=click.Path(), default=None, help="Path to local Mbed OS directory.",
 )
 def configure(toolchain: str, mbed_target: str, program_path: str, mbed_os_path: str) -> None:
-    """Exports a mbed_config.cmake file to a .mbedbuild directory in the program root.
+    """Exports a mbed_config.cmake file to build directory in the program root.
 
     The parameters set in the CMake file will be dependent on the combination of
     toolchain and Mbed target provided and these can then control which parts of

--- a/src/mbed_tools/project/_internal/project_data.py
+++ b/src/mbed_tools/project/_internal/project_data.py
@@ -21,7 +21,6 @@ logger = logging.getLogger(__name__)
 # Mbed program file names and constants.
 APP_CONFIG_FILE_NAME = "mbed_app.json"
 BUILD_DIR = "cmake_build"
-CMAKE_CONFIG_FILE_PATH = Path(".mbedbuild", "mbed_config.cmake")
 CMAKELISTS_FILE_NAME = "CMakeLists.txt"
 MAIN_CPP_FILE_NAME = "main.cpp"
 MBED_OS_REFERENCE_FILE_NAME = "mbed-os.lib"
@@ -51,14 +50,12 @@ class MbedProgramFiles:
         app_config_file: Path to mbed_app.json file. This can be `None` if the program doesn't set any custom config.
         mbed_os_ref: Library reference file for MbedOS. All programs require this file.
         cmakelists_file: A top-level CMakeLists.txt containing build definitions for the application.
-        cmake_config_file: Path to the CMake configuration script.
         cmake_build_dir: The CMake build tree.
     """
 
     app_config_file: Optional[Path]
     mbed_os_ref: Path
     cmakelists_file: Path
-    cmake_config_file: Path
     cmake_build_dir: Path
     custom_targets_json: Path
 
@@ -79,7 +76,6 @@ class MbedProgramFiles:
         cmakelists_file = root_path / CMAKELISTS_FILE_NAME
         main_cpp = root_path / MAIN_CPP_FILE_NAME
         gitignore = root_path / ".gitignore"
-        cmake_config = root_path / CMAKE_CONFIG_FILE_PATH
         cmake_build_dir = root_path / BUILD_DIR
         custom_targets_json = root_path / CUSTOM_TARGETS_JSON_FILE_NAME
 
@@ -95,7 +91,6 @@ class MbedProgramFiles:
             app_config_file=app_config,
             mbed_os_ref=mbed_os_ref,
             cmakelists_file=cmakelists_file,
-            cmake_config_file=cmake_config,
             cmake_build_dir=cmake_build_dir,
             custom_targets_json=custom_targets_json,
         )
@@ -126,7 +121,6 @@ class MbedProgramFiles:
             app_config_file=app_config,
             mbed_os_ref=mbed_os_file,
             cmakelists_file=cmakelists_file,
-            cmake_config_file=root_path / CMAKE_CONFIG_FILE_PATH,
             cmake_build_dir=cmake_build_dir,
             custom_targets_json=custom_targets_json,
         )

--- a/src/mbed_tools/project/_internal/templates/CMakeLists.tmpl
+++ b/src/mbed_tools/project/_internal/templates/CMakeLists.tmpl
@@ -4,7 +4,7 @@
 cmake_minimum_required(VERSION 3.19.0)
 
 set(MBED_PATH ${CMAKE_CURRENT_SOURCE_DIR}/mbed-os CACHE INTERNAL "")
-set(MBED_CONFIG_PATH ${CMAKE_CURRENT_SOURCE_DIR}/.mbedbuild CACHE INTERNAL "")
+set(MBED_CONFIG_PATH ${CMAKE_CURRENT_BINARY_DIR} CACHE INTERNAL "")
 set(APP_TARGET {{program_name}})
 
 include(${MBED_PATH}/tools/cmake/app.cmake)

--- a/tests/build/test_generate_config.py
+++ b/tests/build/test_generate_config.py
@@ -8,6 +8,7 @@ import pytest
 
 from mbed_tools.project import MbedProgram
 from mbed_tools.build import generate_config
+from mbed_tools.build.config import CMAKE_CONFIG_FILE
 from mbed_tools.lib.exceptions import ToolsError
 
 
@@ -84,7 +85,7 @@ def test_target_and_toolchain_collected(program):
 
     generate_config(target, toolchain, program)
 
-    config_text = program.files.cmake_config_file.read_text()
+    config_text = (program.files.cmake_build_dir / CMAKE_CONFIG_FILE).read_text()
 
     assert target in config_text
     assert toolchain in config_text
@@ -97,7 +98,7 @@ def test_custom_targets_data_found(program):
 
     generate_config(target, toolchain, program)
 
-    config_text = program.files.cmake_config_file.read_text()
+    config_text = (program.files.cmake_build_dir / CMAKE_CONFIG_FILE).read_text()
 
     assert target in config_text
 
@@ -125,7 +126,7 @@ def test_config_param_from_lib_processed_with_default_name_mangling(program):
 
     generate_config("K64F", "GCC_ARM", program)
 
-    config_text = program.files.cmake_config_file.read_text()
+    config_text = (program.files.cmake_build_dir / CMAKE_CONFIG_FILE).read_text()
 
     assert "MBED_CONF_PLATFORM_STDIO_CONVERT_NEWLINES" in config_text
 
@@ -145,7 +146,7 @@ def test_config_param_from_lib_processed_with_user_set_name(program):
 
     generate_config("K64F", "GCC_ARM", program)
 
-    config_text = program.files.cmake_config_file.read_text()
+    config_text = (program.files.cmake_build_dir / CMAKE_CONFIG_FILE).read_text()
 
     assert "ENABLE_NEWLINES" in config_text
 
@@ -163,7 +164,7 @@ def test_config_param_from_app_processed_with_default_name_mangling(program):
 
     generate_config("K64F", "GCC_ARM", program)
 
-    config_text = program.files.cmake_config_file.read_text()
+    config_text = (program.files.cmake_build_dir / CMAKE_CONFIG_FILE).read_text()
 
     assert "MBED_CONF_APP_STDIO_CONVERT_NEWLINES" in config_text
 
@@ -171,7 +172,7 @@ def test_config_param_from_app_processed_with_default_name_mangling(program):
 def test_config_param_from_target_processed_with_default_name_mangling(program):
     generate_config("K64F", "GCC_ARM", program)
 
-    config_text = program.files.cmake_config_file.read_text()
+    config_text = (program.files.cmake_build_dir / CMAKE_CONFIG_FILE).read_text()
 
     assert "MBED_CONF_TARGET_XIP_ENABLE=0" in config_text
 
@@ -186,7 +187,7 @@ def test_macros_from_lib_collected(macros, program):
 
     generate_config("K64F", "GCC_ARM", program)
 
-    config_text = program.files.cmake_config_file.read_text()
+    config_text = (program.files.cmake_build_dir / CMAKE_CONFIG_FILE).read_text()
 
     for macro in macros:
         assert macro in config_text
@@ -202,7 +203,7 @@ def test_macros_from_app_collected(macros, program):
 
     generate_config("K64F", "GCC_ARM", program)
 
-    config_text = program.files.cmake_config_file.read_text()
+    config_text = (program.files.cmake_build_dir / CMAKE_CONFIG_FILE).read_text()
 
     for macro in macros:
         assert macro in config_text
@@ -211,7 +212,7 @@ def test_macros_from_app_collected(macros, program):
 def test_macros_from_target_collected(program):
     generate_config("K64F", "GCC_ARM", program)
 
-    config_text = program.files.cmake_config_file.read_text()
+    config_text = (program.files.cmake_build_dir / CMAKE_CONFIG_FILE).read_text()
 
     for macro in TARGET_DATA["macros"]:
         assert macro in config_text
@@ -220,7 +221,7 @@ def test_macros_from_target_collected(program):
 def test_target_labels_collected_as_defines(program):
     generate_config("K64F", "GCC_ARM", program)
 
-    config_text = program.files.cmake_config_file.read_text()
+    config_text = (program.files.cmake_build_dir / CMAKE_CONFIG_FILE).read_text()
 
     for label in TARGET_DATA["labels"] + TARGET_DATA["extra_labels"]:
         assert f"TARGET_{label}" in config_text
@@ -247,7 +248,7 @@ def test_overrides_lib_config_param_from_app(matching_target_and_filter, program
     create_mbed_app_json(program.root, target_overrides={target_filter: {"platform.stdio-baud-rate": 115200}})
     generate_config(target, "GCC_ARM", program)
 
-    config_text = program.files.cmake_config_file.read_text()
+    config_text = (program.files.cmake_build_dir / CMAKE_CONFIG_FILE).read_text()
 
     assert "MBED_CONF_PLATFORM_STDIO_BAUD_RATE=115200" in config_text
 
@@ -258,7 +259,7 @@ def test_overrides_target_config_param_from_app(matching_target_and_filter, prog
 
     generate_config(target, "GCC_ARM", program)
 
-    config_text = program.files.cmake_config_file.read_text()
+    config_text = (program.files.cmake_build_dir / CMAKE_CONFIG_FILE).read_text()
 
     assert "MBED_CONF_TARGET_XIP_ENABLE=1" in config_text
 
@@ -284,7 +285,7 @@ def test_overrides_target_non_config_params_from_app(
 
     generate_config(target, "GCC_ARM", program)
 
-    config_text = program.files.cmake_config_file.read_text()
+    config_text = (program.files.cmake_build_dir / CMAKE_CONFIG_FILE).read_text()
 
     assert expected_output in config_text
 
@@ -299,7 +300,7 @@ def test_overrides_target_config_param_from_lib(matching_target_and_filter, prog
 
     generate_config(target, "GCC_ARM", program)
 
-    config_text = program.files.cmake_config_file.read_text()
+    config_text = (program.files.cmake_build_dir / CMAKE_CONFIG_FILE).read_text()
 
     assert "MBED_CONF_TARGET_XIP_ENABLE=1" in config_text
 
@@ -315,7 +316,7 @@ def test_overrides_lib_config_param_from_same_lib(matching_target_and_filter, pr
 
     generate_config(target, "GCC_ARM", program)
 
-    config_text = program.files.cmake_config_file.read_text()
+    config_text = (program.files.cmake_build_dir / CMAKE_CONFIG_FILE).read_text()
 
     assert "MBED_CONF_PLATFORM_STDIO_BAUD_RATE=115200" in config_text
 
@@ -354,7 +355,7 @@ def test_target_list_params_can_be_added_to(
 
     generate_config(target, "GCC_ARM", program)
 
-    config_text = program.files.cmake_config_file.read_text()
+    config_text = (program.files.cmake_build_dir / CMAKE_CONFIG_FILE).read_text()
 
     for expected in expected_output:
         assert expected in config_text
@@ -379,7 +380,7 @@ def test_target_list_params_can_be_removed(
 
     generate_config(target, "GCC_ARM", program)
 
-    config_text = program.files.cmake_config_file.read_text()
+    config_text = (program.files.cmake_build_dir / CMAKE_CONFIG_FILE).read_text()
 
     assert expected_output not in config_text
 
@@ -407,7 +408,7 @@ def test_settings_from_multiple_libs_included(matching_target_and_filter, progra
 
     generate_config(target, "GCC_ARM", program)
 
-    config_text = program.files.cmake_config_file.read_text()
+    config_text = (program.files.cmake_build_dir / CMAKE_CONFIG_FILE).read_text()
 
     assert "MBED_CONF_PLATFORM_STDIO_BAUD_RATE=9600" in config_text
     assert "MBED_LFS_READ_SIZE=64" in config_text
@@ -427,7 +428,7 @@ def test_requires_config_option(program):
 
     generate_config("K64F", "GCC_ARM", program)
 
-    config_text = program.files.cmake_config_file.read_text()
+    config_text = (program.files.cmake_build_dir / CMAKE_CONFIG_FILE).read_text()
 
     assert "MBED_CONF_PLATFORM_STDIO_BAUD_RATE=9600" in config_text
     assert "MBED_LFS_READ_SIZE=64" not in config_text
@@ -451,7 +452,7 @@ def test_target_requires_config_option(program):
 
     generate_config("K64F", "GCC_ARM", program)
 
-    config_text = program.files.cmake_config_file.read_text()
+    config_text = (program.files.cmake_build_dir / CMAKE_CONFIG_FILE).read_text()
 
     assert "MBED_CONF_PLATFORM_STDIO_BAUD_RATE=9600" in config_text
     assert "MBED_LFS_READ_SIZE=64" not in config_text

--- a/tests/cli/test_build.py
+++ b/tests/cli/test_build.py
@@ -12,7 +12,8 @@ from unittest import TestCase, mock
 from click.testing import CliRunner
 
 from mbed_tools.cli.build import build
-from mbed_tools.project._internal.project_data import BUILD_DIR, CMAKE_CONFIG_FILE_PATH
+from mbed_tools.project._internal.project_data import BUILD_DIR
+from mbed_tools.build.config import CMAKE_CONFIG_FILE
 
 
 DEFAULT_BUILD_ARGS = ["-t", "GCC_ARM", "-m", "K64F"]
@@ -28,9 +29,9 @@ def mock_project_directory(
         root.mkdir()
         program.root = root
         program.files.cmake_build_dir = root / BUILD_DIR / build_subdir
-        program.files.cmake_config_file = root / CMAKE_CONFIG_FILE_PATH
+        program.files.cmake_config_file = root / BUILD_DIR / build_subdir / CMAKE_CONFIG_FILE
         if mbed_config_exists:
-            program.files.cmake_config_file.parent.mkdir(exist_ok=True)
+            program.files.cmake_config_file.parent.mkdir(exist_ok=True, parents=True)
             program.files.cmake_config_file.touch(exist_ok=True)
 
         if build_tree_exists:

--- a/travis-ci/test-data/TARGET_IMAGINARYBOARD/CMakeLists.txt
+++ b/travis-ci/test-data/TARGET_IMAGINARYBOARD/CMakeLists.txt
@@ -1,16 +1,16 @@
 # Copyright (c) 2020-2021 Arm Limited and Contributors. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-add_library(IMAGINARYBOARD INTERFACE)
+add_library(mbed-imaginaryboard INTERFACE)
 
-target_sources(IMAGINARYBOARD
+target_sources(mbed-imaginaryboard
     INTERFACE
         PeripheralPins.c
 )
 
-target_include_directories(IMAGINARYBOARD
+target_include_directories(mbed-imaginaryboard
     INTERFACE
         .
 )
 
-target_link_libraries(IMAGINARYBOARD INTERFACE STM32L475xG)
+target_link_libraries(mbed-imaginaryboard INTERFACE mbed-stm32l475xg)


### PR DESCRIPTION
### Description

The `MbedProgramFiles` contains list of files related to an Mbed program. When a new Mbed program gets created then `MbedProgramFiles` is instantiated. However, location of mbed config cmake file `mbed_config.cmake` is not known at this stage. Therefore, move `mbed_config.cmake` to config component where it'll be first used.



### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [x]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
