### PR TITLE
project: Add support for SSH syntax in import

### DIFF
--- a/news/169.bugfix
+++ b/news/169.bugfix
@@ -1,0 +1,1 @@
+Support use of user@host:directory syntax with the import subcommand.

--- a/src/mbed_tools/project/mbed_program.py
+++ b/src/mbed_tools/project/mbed_program.py
@@ -113,6 +113,9 @@ def parse_url(name_or_url: str) -> Dict[str, str]:
     url_obj = urlparse(name_or_url)
     if url_obj.hostname:
         url = url_obj.geturl()
+    elif ":" in name_or_url.split("/", maxsplit=1)[0]:
+        # If non-standard and no slashes before first colon, git will recognize as scp ssh syntax
+        url = name_or_url
     else:
         url = f"https://github.com/armmbed/{url_obj.path}"
     # We need to create a valid directory name from the url path section.

--- a/tests/project/test_mbed_program.py
+++ b/tests/project/test_mbed_program.py
@@ -127,6 +127,12 @@ class TestParseURL(TestCase):
         self.assertEqual(data["url"], url)
         self.assertEqual(data["dst_path"], "mbed-os-example-numskull")
 
+    def test_creates_valid_dst_dir_from_ssh_url(self):
+        url = "git@superversioncontrol:superorg/mbed-os-example-numskull"
+        data = parse_url(url)
+        self.assertEqual(data["url"], url)
+        self.assertEqual(data["dst_path"], "mbed-os-example-numskull")
+
 
 class TestFindProgramRoot(TestCase):
     @patchfs


### PR DESCRIPTION
### Description

The parser in the `import` subcommand causes errors when using scp-like `user@host:directory` SSH syntax, as it is not recognized by `urllib.parse` as a standard URL, and is treated as a project name instead. This adds a check for non-standard URLs, using the URL if it meets git scp-like requirements. This does not affect importing ARMmbed projects by name.

Fixes #169

### Test Coverage


- [x]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
