### PR TITLE
config: Check namespace when applying overrides

### DIFF
--- a/news/191.bugfix
+++ b/news/191.bugfix
@@ -1,0 +1,1 @@
+Take namespaces into account when applying target overrides.

--- a/src/mbed_tools/build/_internal/config/config.py
+++ b/src/mbed_tools/build/_internal/config/config.py
@@ -34,7 +34,7 @@ class Config(UserDict):
 
     def _handle_overrides(self, overrides: Iterable[Override]) -> None:
         for override in overrides:
-            logger.debug("Applying override '%s.%s'", override.namespace, override.name)
+            logger.debug("Applying override '%s.%s'='%s'", override.namespace, override.name, repr(override.value))
             if override.name == "requires":
                 self.data["requires"] = self.data.get("requires", set()) | override.value
                 continue

--- a/src/mbed_tools/build/_internal/config/config.py
+++ b/src/mbed_tools/build/_internal/config/config.py
@@ -43,7 +43,7 @@ class Config(UserDict):
                 _apply_override(self.data, override)
                 continue
 
-            setting = self._find_config_setting(lambda x: x.name == override.name)
+            setting = self._find_config_setting(lambda x: x.name == override.name and x.namespace == override.namespace)
             setting.value = override.value
 
     def _update_config_section(self, config_settings: List[ConfigSetting]) -> None:

--- a/tests/build/_internal/config/test_config.py
+++ b/tests/build/_internal/config/test_config.py
@@ -47,6 +47,30 @@ class TestConfig:
         assert network_iface.value == "ETHERNET"
         assert conf["device_has"] == {"OVERRIDDEN"}
 
+    def test_target_overrides_separate_namespace(self):
+        conf = Config(
+            {
+                "config": [
+                    ConfigSetting(
+                        namespace="dontchangeme", name="network-default-interface-type", help_text="", value="WIFI"
+                    ),
+                    ConfigSetting(
+                        namespace="changeme", name="network-default-interface-type", help_text="", value="WIFI"
+                    ),
+                ]
+            }
+        )
+
+        conf.update(
+            {"overrides": [Override(namespace="changeme", name="network-default-interface-type", value="ETHERNET")]}
+        )
+
+        dontchangeme, changeme, *_ = conf["config"]
+        assert changeme.namespace == "changeme"
+        assert changeme.value == "ETHERNET"
+        assert dontchangeme.namespace == "dontchangeme"
+        assert dontchangeme.value == "WIFI"
+
     def test_lib_overrides_handled(self):
         conf = Config(
             {


### PR DESCRIPTION
### Description

Previously, when applying overrides, we were finding the first config
setting with a name that matches the the override name. When different
setting namespaces contained settings with the same name, this led to
applying overrides to only the first setting rather than the correct
setting. To fix this, check both name and namespace when searching for
settings to override.

### Test Coverage

- [X]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
