### PR TITLE
 detect: Raise an error when running on unknown OS

### DIFF
--- a/news/20210218112043.bugfix
+++ b/news/20210218112043.bugfix
@@ -1,0 +1,1 @@
+Raise a nicer error from mbed-tools detect when running on an unrecognised OS.

--- a/src/mbed_tools/devices/_internal/detect_candidate_devices.py
+++ b/src/mbed_tools/devices/_internal/detect_candidate_devices.py
@@ -8,6 +8,7 @@ from typing import Iterable
 
 from mbed_tools.devices._internal.candidate_device import CandidateDevice
 from mbed_tools.devices._internal.base_detector import DeviceDetector
+from mbed_tools.devices.exceptions import UnknownOSError
 
 
 def detect_candidate_devices() -> Iterable[CandidateDevice]:
@@ -26,7 +27,12 @@ def _get_detector_for_current_os() -> DeviceDetector:
         from mbed_tools.devices._internal.linux.device_detector import LinuxDeviceDetector
 
         return LinuxDeviceDetector()
-    else:
+    if platform.system() == "Darwin":
         from mbed_tools.devices._internal.darwin.device_detector import DarwinDeviceDetector
 
         return DarwinDeviceDetector()
+
+    raise UnknownOSError(
+        f"We have detected the OS you are running is '{platform.system()}'. "
+        "Unfortunately we haven't implemented device detection support for this OS yet. Sorry!"
+    )

--- a/src/mbed_tools/devices/exceptions.py
+++ b/src/mbed_tools/devices/exceptions.py
@@ -16,3 +16,7 @@ class DeviceLookupFailed(MbedDevicesError):
 
 class NoDevicesFound(MbedDevicesError):
     """No Mbed Enabled devices were found."""
+
+
+class UnknownOSError(MbedDevicesError):
+    """The current OS is not supported."""

--- a/tests/devices/_internal/test_detect_candidate_devices.py
+++ b/tests/devices/_internal/test_detect_candidate_devices.py
@@ -2,7 +2,7 @@
 # Copyright (c) 2020-2021 Arm Limited and Contributors. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
-from unittest import TestCase, mock
+from unittest import mock
 
 from tests.devices.markers import windows_only, darwin_only, linux_only
 from mbed_tools.devices._internal.base_detector import DeviceDetector
@@ -12,29 +12,29 @@ from mbed_tools.devices._internal.detect_candidate_devices import (
 )
 
 
-class TestDetectCandidateDevices(TestCase):
+class TestDetectCandidateDevices:
     @mock.patch("mbed_tools.devices._internal.detect_candidate_devices._get_detector_for_current_os")
     def test_returns_candidates_using_os_specific_detector(self, _get_detector_for_current_os):
         detector = mock.Mock(spec_set=DeviceDetector)
         _get_detector_for_current_os.return_value = detector
-        self.assertEqual(detect_candidate_devices(), detector.find_candidates.return_value)
+        assert detect_candidate_devices() == detector.find_candidates.return_value
 
 
-class TestGetDetectorForCurrentOS(TestCase):
+class TestGetDetectorForCurrentOS:
     @windows_only
     def test_windows_uses_correct_module(self):
         from mbed_tools.devices._internal.windows.device_detector import WindowsDeviceDetector
 
-        self.assertIsInstance(_get_detector_for_current_os(), WindowsDeviceDetector)
+        assert isinstance(_get_detector_for_current_os(), WindowsDeviceDetector)
 
     @darwin_only
     def test_darwin_uses_correct_module(self):
         from mbed_tools.devices._internal.darwin.device_detector import DarwinDeviceDetector
 
-        self.assertIsInstance(_get_detector_for_current_os(), DarwinDeviceDetector)
+        assert isinstance(_get_detector_for_current_os(), DarwinDeviceDetector)
 
     @linux_only
     def test_linux_uses_correct_module(self):
         from mbed_tools.devices._internal.linux.device_detector import LinuxDeviceDetector
 
-        self.assertIsInstance(_get_detector_for_current_os(), LinuxDeviceDetector)
+        assert isinstance(_get_detector_for_current_os(), LinuxDeviceDetector)

--- a/tests/devices/_internal/test_detect_candidate_devices.py
+++ b/tests/devices/_internal/test_detect_candidate_devices.py
@@ -2,10 +2,12 @@
 # Copyright (c) 2020-2021 Arm Limited and Contributors. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
+import pytest
 from unittest import mock
 
 from tests.devices.markers import windows_only, darwin_only, linux_only
 from mbed_tools.devices._internal.base_detector import DeviceDetector
+from mbed_tools.devices.exceptions import UnknownOSError
 from mbed_tools.devices._internal.detect_candidate_devices import (
     detect_candidate_devices,
     _get_detector_for_current_os,
@@ -38,3 +40,11 @@ class TestGetDetectorForCurrentOS:
         from mbed_tools.devices._internal.linux.device_detector import LinuxDeviceDetector
 
         assert isinstance(_get_detector_for_current_os(), LinuxDeviceDetector)
+
+    @mock.patch("platform.system")
+    def test_raises_when_os_is_unknown(self, platform_system):
+        os_name = "SomethingNobodyUses"
+        platform_system.return_value = os_name
+
+        with pytest.raises(UnknownOSError):
+            _get_detector_for_current_os()


### PR DESCRIPTION
### Description

<!--
Please add any detail or context that would be useful to a reviewer.
-->


Previously the detection code seemed to think if the user wasn't running
Linux or Windows they must be running macOS. That would be great, but
unfortunately this isn't the case and other OSes do exist.

This PR adds an UnknownOSError and raises it when platform.system
detects an OS we don't understand.

Fixes #177
### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [x]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
