### PR TITLE
new: Fix for create a new Mbed OS project bug

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -180,8 +180,13 @@ matrix:
       name: "Test new command"
       env: NAME=test-new-cmd CACHE_NAME=test-new-cmd
       script:
+        # Create a new Mbed OS project named "test"
         - mbedtools new test
         - cd test
+        - mbedtools compile -t GCC_ARM -m K64F
+        - cd .. && mkdir mbed-os-example && cd mbed-os-example
+        # Create a new Mbed OS project in current directory
+        - mbedtools new .
         - mbedtools compile -t GCC_ARM -m K64F
         - ccache -s
 

--- a/news/20210218122316.bugfix
+++ b/news/20210218122316.bugfix
@@ -1,0 +1,1 @@
+Fix for create a new Mbed OS project in current directory bug.

--- a/src/mbed_tools/cli/project_management.py
+++ b/src/mbed_tools/cli/project_management.py
@@ -17,7 +17,7 @@ from mbed_tools.project._internal import git_utils
 
 @click.command()
 @click.option("--create-only", "-c", is_flag=True, show_default=True, help="Create a program without fetching mbed-os.")
-@click.argument("path", type=click.Path())
+@click.argument("path", type=click.Path(resolve_path=True))
 def new(path: str, create_only: bool) -> None:
     """Creates a new Mbed project at the specified path. Downloads mbed-os and adds it to the project.
 

--- a/tests/cli/test_project_management.py
+++ b/tests/cli/test_project_management.py
@@ -41,10 +41,16 @@ def mock_get_libs():
 class TestNewCommand:
     def test_calls_new_function_with_correct_args(self, mock_initialise_project):
         CliRunner().invoke(new, ["path", "--create-only"])
-        mock_initialise_project.assert_called_once_with(pathlib.Path("path"), True)
+        mock_initialise_project.assert_called_once_with(pathlib.Path.cwd() / "path", True)
 
     def test_echos_mbed_os_message_when_required(self, mock_initialise_project):
-        expected = "Creating a new Mbed program at path 'path'.\nDownloading mbed-os and adding it to the project.\n"
+        expected = (
+            "Creating a new Mbed program at path "
+            + "'"
+            + str(pathlib.Path.cwd() / "path")
+            + "'"
+            + ".\nDownloading mbed-os and adding it to the project.\n"
+        )
 
         result = CliRunner().invoke(new, ["path"])
 


### PR DESCRIPTION
### Description
If current directory (".") is passed as argument to `mbed-tools new`
then generated `CMakeList.txt` was missing application target name.

Use absolute path instead of relative path while retrieving path details
from command line.

Fixes https://github.com/ARMmbed/mbed-tools/issues/195

<!--
Please add any detail or context that would be useful to a reviewer.
-->



### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [x]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
