### PR TITLE
devices: Add IDs for devices when multiple of the same type are connected

### DIFF
--- a/news/181.feature
+++ b/news/181.feature
@@ -1,0 +1,1 @@
+Add IDs to allow selection of a specific device when multiple of the same type are connected.

--- a/src/mbed_tools/build/flash.py
+++ b/src/mbed_tools/build/flash.py
@@ -47,7 +47,7 @@ def _build_binary_file_path(program_path: pathlib.Path, build_dir: pathlib.Path,
 
 def flash_binary(
     mount_point: pathlib.Path, program_path: pathlib.Path, build_dir: pathlib.Path, mbed_target: str, hex_file: bool
-) -> None:
+) -> pathlib.Path:
     """Flash binary onto a device.
 
     Look through the connected devices and flash the binary if the connected and built target matches.
@@ -61,3 +61,4 @@ def flash_binary(
     """
     fw_file = _build_binary_file_path(program_path, build_dir, hex_file)
     _flash_dev(mount_point, fw_file)
+    return fw_file

--- a/src/mbed_tools/cli/build.py
+++ b/src/mbed_tools/cli/build.py
@@ -110,7 +110,8 @@ def build(
 
     if flash:
         for dev in devices:
-            flash_binary(dev.mount_points[0].resolve(), program.root, build_tree, mbed_target, hex_file)
+            flashed_path = flash_binary(dev.mount_points[0].resolve(), program.root, build_tree, mbed_target, hex_file)
+        click.echo(f"Copied {str(flashed_path.resolve())} to {len(devices)} device(s).")
     elif hex_file:
         click.echo("'--hex-file' option should be used with '-f/--flash' option")
 

--- a/src/mbed_tools/cli/sterm.py
+++ b/src/mbed_tools/cli/sterm.py
@@ -7,7 +7,8 @@ from typing import Any, Optional
 
 import click
 
-from mbed_tools.devices import get_connected_devices, find_connected_device
+from mbed_tools.cli.build import _get_target_id
+from mbed_tools.devices import find_connected_device, get_connected_devices
 from mbed_tools.devices.exceptions import MbedDevicesError
 from mbed_tools.sterm import terminal
 
@@ -52,6 +53,6 @@ def _find_target_serial_port_or_default(target: Optional[str]) -> Any:
         # just return the first valid device found
         device, *_ = _get_connected_mbed_devices()
     else:
-        device = find_connected_device(target.upper())
-
+        target_name, target_id = _get_target_id(target)
+        device = find_connected_device(target_name.upper(), target_id)
     return device.serial_port

--- a/src/mbed_tools/devices/__init__.py
+++ b/src/mbed_tools/devices/__init__.py
@@ -10,6 +10,10 @@ Please see the documentation for mbed-targets for information on configuration o
 
 For the command line interface to the API see the package https://github.com/ARMmbed/mbed-tools
 """
-from mbed_tools.devices.devices import get_connected_devices, find_connected_device
+from mbed_tools.devices.devices import (
+    get_connected_devices,
+    find_connected_device,
+    find_all_connected_devices,
+)
 from mbed_tools.devices.device import Device
 from mbed_tools.devices import exceptions

--- a/tests/cli/test_build.py
+++ b/tests/cli/test_build.py
@@ -182,24 +182,36 @@ class TestBuildCommand(TestCase):
             self.assertFalse(program.files.cmake_build_dir.exists())
 
     @mock.patch("mbed_tools.cli.build.flash_binary")
-    @mock.patch("mbed_tools.cli.build.find_connected_device")
+    @mock.patch("mbed_tools.cli.build.find_all_connected_devices")
     def test_build_flash_option(
-        self, mock_find_device, flash_binary, generate_config, mbed_program, build_project, generate_build_system
+        self, mock_find_devices, flash_binary, generate_config, mbed_program, build_project, generate_build_system
     ):
+        mock_find_devices.return_value = [mock.MagicMock()]
         runner = CliRunner()
         runner.invoke(build, ["--flash", *DEFAULT_BUILD_ARGS])
         flash_binary.assert_called_once()
 
     @mock.patch("mbed_tools.cli.build.flash_binary")
-    @mock.patch("mbed_tools.cli.build.find_connected_device")
+    @mock.patch("mbed_tools.cli.build.find_all_connected_devices")
     def test_build_flash_and_hex_file_options(
-        self, mock_find_device, flash_binary, generate_config, mbed_program, build_project, generate_build_system
+        self, mock_find_devices, flash_binary, generate_config, mbed_program, build_project, generate_build_system
     ):
+        mock_find_devices.return_value = [mock.MagicMock()]
         runner = CliRunner()
         runner.invoke(build, ["--flash", "--hex-file", *DEFAULT_BUILD_ARGS])
         call_args = flash_binary.call_args
         args, kwargs = call_args
         flash_binary.assert_called_once_with(args[0], args[1], args[2], args[3], True)
+
+    @mock.patch("mbed_tools.cli.build.flash_binary")
+    @mock.patch("mbed_tools.cli.build.find_all_connected_devices")
+    def test_build_flash_both_two_devices(
+        self, mock_find_devices, flash_binary, generate_config, mbed_program, build_project, generate_build_system
+    ):
+        mock_find_devices.return_value = [mock.MagicMock(), mock.MagicMock()]
+        runner = CliRunner()
+        runner.invoke(build, ["--flash", *DEFAULT_BUILD_ARGS])
+        self.assertEqual(flash_binary.call_count, 2)
 
     def test_build_only_hex_file_option(self, generate_config, mbed_program, build_project, generate_build_system):
         runner = CliRunner()

--- a/tests/cli/test_list_connected_devices.py
+++ b/tests/cli/test_list_connected_devices.py
@@ -153,8 +153,48 @@ class TestBuildTableOutput(TestCase):
                     device.serial_number,
                     device.serial_port,
                     "\n".join(map(str, device.mount_points)),
-                    "\n".join(_get_build_targets(device.mbed_board)),
+                    "\n".join(_get_build_targets(device.mbed_board, None)),
                 ]
+            ],
+            headers=["Board name", "Serial number", "Serial port", "Mount point(s)", "Build target(s)"],
+        )
+        self.assertEqual(output, expected_output)
+
+    def test_returns_tabularised_with_identifier(self):
+        board = mock.create_autospec(
+            Board, board_name="board-name", build_variant=("S", "NS"), board_type="board-type",
+        )
+        device = Device(
+            mbed_board=board,
+            serial_number="123",
+            serial_port="serial-port",
+            mount_points=[pathlib.Path("/Volumes/FOO"), pathlib.Path("/Volumes/BAR")],
+        )
+        device_2 = Device(
+            mbed_board=board,
+            serial_number="456",
+            serial_port="serial-port",
+            mount_points=[pathlib.Path("/Volumes/FOO"), pathlib.Path("/Volumes/BAR")],
+        )
+
+        output = _build_tabular_output([device, device_2])
+
+        expected_output = tabulate(
+            [
+                [
+                    f"{device.mbed_board.board_name}",
+                    device.serial_number,
+                    device.serial_port,
+                    "\n".join(map(str, device.mount_points)),
+                    "\n".join(_get_build_targets(board, 0)),
+                ],
+                [
+                    f"{device_2.mbed_board.board_name}",
+                    device_2.serial_number,
+                    device_2.serial_port,
+                    "\n".join(map(str, device_2.mount_points)),
+                    "\n".join(_get_build_targets(board, 1)),
+                ],
             ],
             headers=["Board name", "Serial number", "Serial port", "Mount point(s)", "Build target(s)"],
         )
@@ -177,7 +217,7 @@ class TestBuildTableOutput(TestCase):
                     device.serial_number,
                     "<unknown>",
                     "\n".join(map(str, device.mount_points)),
-                    "\n".join(_get_build_targets(device.mbed_board)),
+                    "\n".join(_get_build_targets(device.mbed_board, None)),
                 ]
             ],
             headers=["Board name", "Serial number", "Serial port", "Mount point(s)", "Build target(s)"],
@@ -213,9 +253,61 @@ class TestBuildJsonOutput(TestCase):
                         "board_name": board.board_name,
                         "mbed_os_support": board.mbed_os_support,
                         "mbed_enabled": board.mbed_enabled,
-                        "build_targets": _get_build_targets(board),
+                        "build_targets": _get_build_targets(board, None),
                     },
                 }
+            ],
+            indent=4,
+        )
+
+        self.assertEqual(output, expected_output)
+
+    def test_returns_json_representation_with_identifier(self):
+        board = mock.create_autospec(
+            Board,
+            product_code="0021",
+            board_type="HAT-BOAT",
+            board_name="HAT Boat",
+            mbed_os_support=["0.2"],
+            mbed_enabled=["potentially"],
+            build_variant=("S", "NS"),
+        )
+        device = Device(
+            mbed_board=board, serial_number="09887654", serial_port="COM1", mount_points=[pathlib.Path("somepath")],
+        )
+        device_2 = Device(
+            mbed_board=board, serial_number="09884321", serial_port="COM2", mount_points=[pathlib.Path("anotherpath")],
+        )
+
+        output = _build_json_output([device, device_2])
+        expected_output = json.dumps(
+            [
+                {
+                    "serial_number": device.serial_number,
+                    "serial_port": device.serial_port,
+                    "mount_points": [str(m) for m in device.mount_points],
+                    "mbed_board": {
+                        "product_code": board.product_code,
+                        "board_type": board.board_type,
+                        "board_name": board.board_name,
+                        "mbed_os_support": board.mbed_os_support,
+                        "mbed_enabled": board.mbed_enabled,
+                        "build_targets": _get_build_targets(board, 0),
+                    },
+                },
+                {
+                    "serial_number": device_2.serial_number,
+                    "serial_port": device_2.serial_port,
+                    "mount_points": [str(m) for m in device_2.mount_points],
+                    "mbed_board": {
+                        "product_code": board.product_code,
+                        "board_type": board.board_type,
+                        "board_name": board.board_name,
+                        "mbed_os_support": board.mbed_os_support,
+                        "mbed_enabled": board.mbed_enabled,
+                        "build_targets": _get_build_targets(board, 1),
+                    },
+                },
             ],
             indent=4,
         )
@@ -237,4 +329,8 @@ class TestGetBuildTargets(TestCase):
     def test_returns_base_target_and_all_variants(self):
         board = mock.create_autospec(Board, build_variant=("S", "NS"), board_type="FOO")
 
-        self.assertEqual(_get_build_targets(board), ["FOO_S", "FOO_NS", "FOO"])
+        self.assertEqual(_get_build_targets(board, None), ["FOO_S", "FOO_NS", "FOO"])
+
+    def test_returns_base_and_variants_identifier(self):
+        board = mock.create_autospec(Board, build_variant=("S", "NS"), board_type="FOO")
+        self.assertEqual(_get_build_targets(board, 2), ["FOO_S[2]", "FOO_NS[2]", "FOO[2]"])

--- a/tests/cli/test_sterm.py
+++ b/tests/cli/test_sterm.py
@@ -81,8 +81,24 @@ def test_returns_serial_port_for_first_device_detected_if_no_target_given(mock_g
     mock_terminal.run.assert_called_once_with(expected_port, 9600, echo=True)
 
 
+def test_returns_serial_port_for_device_if_identifier_given(mock_find_device, mock_terminal):
+    expected_port = "tty.k64f"
+    mock_find_device.return_value = mock.Mock(serial_port=expected_port, mbed_board=mock.Mock(board_type="K64F"))
+
+    CliRunner().invoke(sterm, ["-m", "K64F[1]"])
+
+    mock_terminal.run.assert_called_once_with(expected_port, 9600, echo=True)
+
+
 def test_raises_when_fails_to_find_default_device(mock_get_devices, mock_terminal):
     mock_get_devices.return_value = mock.Mock(identified_devices=[])
 
     with pytest.raises(MbedDevicesError):
         CliRunner().invoke(sterm, [], catch_exceptions=False)
+
+
+def test_not_run_if_target_identifier_not_int(mock_get_devices, mock_terminal):
+    target = "K64F[foo]"
+    CliRunner().invoke(sterm, ["-m", target], catch_exceptions=False)
+    mock_get_devices.assert_not_called()
+    mock_terminal.assert_not_called()


### PR DESCRIPTION
### Description

Refactor device detection to allow for use of multiple of the same device, without having to manually remove, and to clarify default flash behavior in this case.

Previously, if a user had multiple of the same `mbed-target` connected, the behavior of `mbed-tools` was to use the first device found which matches the given `mbed_target`, regardless of how many are connected. That leads to unclear behavior with `compile -f/--sterm`, and `sterm` subcommands, and requires manual disconnecting of devices to flash or start a serial terminal with a specific device.

Modified the default behavior of `compile -f` to find all connected devices of the target type, and flash all that are found, rather than just flashing the first one found.

Allow users to specify a device to use with an ID in `compile` and `sterm`: `mbed_target[ID]`. This allows use of `-f/--sterm` with any connected device even if others of the same type are connected. The unique build targets with the IDs are displayed with `detect`.

For example the `detect` output from #181 would now be:
```
Board name     Serial number             Serial port    Mount point(s)    Build target(s)
-------------  ------------------------  -------------  ----------------  -----------------
NUCLEO-WB55RG  066dff535456807867075351  COM42          F:                NUCLEO_WB55RG[0]
NUCLEO-WB55RG  066dff545057717867195937  COM26          E:                NUCLEO_WB55RG[1]
```

Added a print statement to `compile -f` to tell the user how many files were copied, and whether they were `.BIN` or `.HEX`.

Fixes #181

### Test Coverage


- [x]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
