### PR TITLE
project: Shallow clone repos

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -197,7 +197,8 @@ matrix:
         - mbedtools import mbed-os-example-ble
         - cd mbed-os-example-ble
         # Checkout the development branch on BLE example
-        - git checkout development
+        - git fetch origin development
+        - git checkout FETCH_HEAD
         - cd BLE_Advertising
         - mbedtools deploy
         - mbedtools compile -t GCC_ARM -m K64F

--- a/news/20210224162840.feature
+++ b/news/20210224162840.feature
@@ -1,0 +1,2 @@
+Speed up obtaining library dependencies by obtaining only the requested library
+revision and no other revision.

--- a/src/mbed_tools/project/_internal/git_utils.py
+++ b/src/mbed_tools/project/_internal/git_utils.py
@@ -7,9 +7,13 @@ from dataclasses import dataclass
 from pathlib import Path
 
 import git
+import logging
 
 from mbed_tools.project.exceptions import VersionControlError
 from mbed_tools.project._internal.progress import ProgressReporter
+from typing import Optional
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -25,21 +29,31 @@ class GitReference:
     ref: str
 
 
-def clone(url: str, dst_dir: Path) -> git.Repo:
+def clone(url: str, dst_dir: Path, ref: Optional[str] = None, depth: int = 1) -> git.Repo:
     """Clone a library repository.
 
     Args:
         url: URL of the remote to clone.
         dst_dir: Destination directory for the cloned repo.
+        ref: An optional git commit hash, branch or tag reference to checkout
+        depth: Truncate history to the specified number of commits. Defaults to
+               1, to make a shallow clone.
 
     Raises:
         VersionControlError: Cloning the repository failed.
     """
+    # Gitpython doesn't propagate the git error message when a repo is already
+    # cloned, so we cannot depend on git to handle the "already cloned" error.
+    # We must handle this ourselves instead.
     if dst_dir.exists() and list(dst_dir.glob("*")):
         raise VersionControlError(f"{dst_dir} exists and is not an empty directory.")
 
+    clone_from_kwargs = {"url": url, "to_path": str(dst_dir), "progress": ProgressReporter(name=url), "depth": depth}
+    if ref:
+        clone_from_kwargs["branch"] = ref
+
     try:
-        return git.Repo.clone_from(url, str(dst_dir), progress=ProgressReporter(name=url))
+        return git.Repo.clone_from(**clone_from_kwargs)
     except git.exc.GitCommandError as err:
         raise VersionControlError(f"Cloning git repository from url '{url}' failed. Error from VCS: {err}")
 
@@ -59,6 +73,22 @@ def checkout(repo: git.Repo, ref: str, force: bool = False) -> None:
         repo.git.checkout(*git_args)
     except git.exc.GitCommandError as err:
         raise VersionControlError(f"Failed to check out revision '{ref}'. Error from VCS: {err}")
+
+
+def fetch(repo: git.Repo, ref: str) -> None:
+    """Fetch from the repo's origin.
+
+    Args:
+        repo: git.Repo object where the checkout will be performed.
+        ref: Git commit hash, branch or tag reference, must be a valid ref defined in the repo.
+
+    Raises:
+        VersionControlError: Fetch failed.
+    """
+    try:
+        repo.git.fetch("origin", ref)
+    except git.exc.GitCommandError as err:
+        raise VersionControlError(f"Failed to fetch. Error from VCS: {err}")
 
 
 def init(path: Path) -> git.Repo:

--- a/tests/project/_internal/test_libraries.py
+++ b/tests/project/_internal/test_libraries.py
@@ -9,6 +9,7 @@ import pytest
 from unittest import mock
 
 from mbed_tools.project._internal.libraries import MbedLibReference, LibraryReferences
+from mbed_tools.project.exceptions import VersionControlError
 from tests.project.factories import make_mbed_lib_reference
 
 
@@ -22,6 +23,12 @@ def mock_clone():
 def mock_checkout():
     with mock.patch("mbed_tools.project._internal.git_utils.checkout") as checkout:
         yield checkout
+
+
+@pytest.fixture
+def mock_fetch():
+    with mock.patch("mbed_tools.project._internal.git_utils.fetch") as fetch:
+        yield fetch
 
 
 @pytest.fixture
@@ -46,7 +53,7 @@ class TestLibraryReferences:
     def test_hydrates_top_level_library_references(self, mock_clone, tmp_path):
         fs_root = pathlib.Path(tmp_path, "foo")
         lib = make_mbed_lib_reference(fs_root, ref_url="https://git")
-        mock_clone.side_effect = lambda url, dst_dir: dst_dir.mkdir()
+        mock_clone.side_effect = lambda url, dst_dir, *args: dst_dir.mkdir()
 
         lib_refs = LibraryReferences(fs_root, ignore_paths=["mbed-os"])
         lib_refs.fetch()
@@ -64,7 +71,7 @@ class TestLibraryReferences:
         )
         # Here we mock the effects of a recursive reference lookup. We create a new lib reference as a side effect of
         # the first call to the mock. Then we create the src dir, thus resolving the lib, on the second call.
-        mock_clone.side_effect = lambda url, dst_dir: (
+        mock_clone.side_effect = lambda url, dst_dir, *args: (
             make_mbed_lib_reference(pathlib.Path(dst_dir), name=lib2.reference_file.name, ref_url="https://valid2"),
             lib2.source_code_path.mkdir(),
         )
@@ -76,7 +83,7 @@ class TestLibraryReferences:
         assert lib2.is_resolved()
 
     def test_does_perform_checkout_of_default_repo_branch_if_no_git_ref_exists(
-        self, mock_get_repo, mock_checkout, mock_get_default_branch, mock_clone, tmp_path
+        self, mock_get_repo, mock_checkout, mock_fetch, mock_get_default_branch, mock_clone, tmp_path
     ):
         fs_root = pathlib.Path(tmp_path, "foo")
         make_mbed_lib_reference(fs_root, ref_url="https://git", resolved=True)
@@ -84,38 +91,95 @@ class TestLibraryReferences:
         lib_refs = LibraryReferences(fs_root, ignore_paths=["mbed-os"])
         lib_refs.checkout(force=False)
 
-        mock_checkout.assert_called_once_with(mock_get_repo(), mock_get_default_branch(), force=False)
+        mock_fetch.assert_called_once_with(mock_get_repo(), mock_get_default_branch())
+        mock_checkout.assert_called_once_with(mock_get_repo(), "FETCH_HEAD", force=False)
 
-    def test_performs_checkout_if_git_ref_exists(self, mock_get_repo, mock_checkout, mock_clone, tmp_path):
+    def test_performs_checkout_if_git_ref_exists(self, mock_get_repo, mock_checkout, mock_fetch, mock_clone, tmp_path):
         fs_root = pathlib.Path(tmp_path, "foo")
         lib = make_mbed_lib_reference(fs_root, ref_url="https://git#lajdhalk234", resolved=True)
 
         lib_refs = LibraryReferences(fs_root, ignore_paths=["mbed-os"])
         lib_refs.checkout(force=False)
 
-        mock_checkout.assert_called_once_with(mock_get_repo.return_value, lib.get_git_reference().ref, force=False)
+        mock_fetch.assert_called_once_with(mock_get_repo(), lib.get_git_reference().ref)
+        mock_checkout.assert_called_once_with(mock_get_repo.return_value, "FETCH_HEAD", force=False)
 
     def test_fetch_does_not_perform_checkout_if_no_git_ref_exists(
-        self, mock_get_repo, mock_checkout, mock_clone, tmp_path
+        self, mock_get_repo, mock_checkout, mock_fetch, mock_clone, tmp_path
     ):
         fs_root = pathlib.Path(tmp_path, "foo")
         make_mbed_lib_reference(fs_root, ref_url="https://git")
-        mock_clone.side_effect = lambda url, dst_dir: dst_dir.mkdir()
+        mock_clone.side_effect = lambda url, dst_dir, *args: dst_dir.mkdir()
 
         lib_refs = LibraryReferences(fs_root, ignore_paths=["mbed-os"])
         lib_refs.fetch()
 
+        mock_fetch.assert_not_called()
         mock_checkout.assert_not_called()
 
-    def test_fetch_performs_checkout_if_git_ref_exists(self, mock_get_repo, mock_checkout, mock_clone, tmp_path):
+    def test_fetch_performs_checkout_if_ref_is_hash(
+        self, mock_get_repo, mock_clone, mock_fetch, mock_checkout, tmp_path
+    ):
+        num_times_called = 0
+
+        def clone_side_effect(url, dst_dir, *args):
+            nonlocal num_times_called
+            if num_times_called == 0:
+                num_times_called += 1
+                raise VersionControlError("Failed to clone")
+            elif num_times_called == 1:
+                num_times_called += 1
+                dst_dir.mkdir()
+            else:
+                assert False
+
         fs_root = pathlib.Path(tmp_path, "foo")
-        lib = make_mbed_lib_reference(fs_root, ref_url="https://git#lajdhalk234")
-        mock_clone.side_effect = lambda url, dst_dir: dst_dir.mkdir()
+        lib = make_mbed_lib_reference(fs_root, ref_url="https://git#398bc1a63370")
+        mock_clone.side_effect = clone_side_effect
 
         lib_refs = LibraryReferences(fs_root, ignore_paths=["mbed-os"])
         lib_refs.fetch()
 
-        mock_checkout.assert_called_once_with(None, lib.get_git_reference().ref)
+        mock_clone.assert_called_with(lib.get_git_reference().repo_url, lib.source_code_path)
+        mock_fetch.assert_called_once_with(None, lib.get_git_reference().ref)
+        mock_checkout.assert_called_once_with(None, "FETCH_HEAD")
+
+    def test_raises_when_no_such_ref(self, mock_repo, mock_clone, mock_fetch, mock_checkout, tmp_path):
+        num_times_called = 0
+
+        def clone_side_effect(url, dst_dir, *args):
+            nonlocal num_times_called
+            if num_times_called == 0:
+                num_times_called += 1
+                raise VersionControlError("Failed to clone")
+            elif num_times_called == 1:
+                num_times_called += 1
+                dst_dir.mkdir()
+            else:
+                assert False
+
+        fs_root = pathlib.Path(tmp_path, "foo")
+        make_mbed_lib_reference(fs_root, ref_url="https://git#lajdhalk234")
+
+        mock_clone.side_effect = clone_side_effect
+        mock_fetch.side_effect = None
+        mock_checkout.side_effect = VersionControlError("Failed to checkout")
+
+        with pytest.raises(VersionControlError, match="Failed to checkout"):
+            lib_refs = LibraryReferences(fs_root, ignore_paths=["mbed-os"])
+            lib_refs.fetch()
+
+    def test_doesnt_fetch_for_branch_or_tag(self, mock_clone, mock_fetch, mock_checkout, tmp_path):
+        fs_root = pathlib.Path(tmp_path, "foo")
+        make_mbed_lib_reference(fs_root, ref_url="https://git#lajdhalk234")
+
+        mock_clone.side_effect = lambda url, dst_dir, *args: dst_dir.mkdir()
+
+        lib_refs = LibraryReferences(fs_root, ignore_paths=["mbed-os"])
+        lib_refs.fetch()
+
+        mock_fetch.assert_not_called()
+        mock_checkout.assert_not_called()
 
     def test_does_not_resolve_references_in_ignore_paths(self, mock_get_repo, mock_checkout, mock_clone, tmp_path):
         fs_root = pathlib.Path(tmp_path, "mbed-os")


### PR DESCRIPTION
Without shallow cloning, cloning Mbed OS can take quite a long while.
Clone with a depth of 1 when resolving library dependencies in order to
speed up cloning. A downside of this approach is that the resulting
repository will not contain other git references than the initial one,
but this can be worked around by performing a subsequent fetch using
`git fetch`.

Example performance improvement on one person's internet connection:
- Old speed for Mbed OS cloning: 1 minute 12.19 seconds
- New speed for Mbed OS cloning: 26.57 seconds

Fixes #178

### Description

Speed up obtaining library dependencies by obtaining only the requested library
revision and no other revision.

### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [X]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
