### PR TITLE
Emit a warning instead of an error when the user attempts to override an undefined configuration parameter

### DIFF
--- a/news/20210301122753.bugfix
+++ b/news/20210301122753.bugfix
@@ -1,0 +1,1 @@
+Emit a warning instead of an error when the user attempts to override an undefined configuration parameter.

--- a/src/mbed_tools/build/_internal/config/config.py
+++ b/src/mbed_tools/build/_internal/config/config.py
@@ -43,10 +43,19 @@ class Config(UserDict):
                 _apply_override(self.data, override)
                 continue
 
-            setting = self._find_first_config_setting(
-                lambda x: x.name == override.name and x.namespace == override.namespace
-            )
-            setting.value = override.value
+            try:
+                setting = self._find_first_config_setting(
+                    lambda x: x.name == override.name and x.namespace == override.namespace
+                )
+                setting.value = override.value
+            except ValueError:
+                logger.warning(
+                    f"You are attempting to override an undefined config parameter "
+                    f"`{override.namespace}.{override.name}`.\n"
+                    "It is an error to override an undefined configuration parameter. "
+                    "Please check your target_overrides are correct.\n"
+                    f"The parameter `{override.namespace}.{override.name}` will not be added to the configuration."
+                )
 
     def _update_config_section(self, config_settings: List[ConfigSetting]) -> None:
         for setting in config_settings:

--- a/src/mbed_tools/build/_internal/config/config.py
+++ b/src/mbed_tools/build/_internal/config/config.py
@@ -43,7 +43,9 @@ class Config(UserDict):
                 _apply_override(self.data, override)
                 continue
 
-            setting = self._find_config_setting(lambda x: x.name == override.name and x.namespace == override.namespace)
+            setting = self._find_first_config_setting(
+                lambda x: x.name == override.name and x.namespace == override.namespace
+            )
             setting.value = override.value
 
     def _update_config_section(self, config_settings: List[ConfigSetting]) -> None:
@@ -56,14 +58,14 @@ class Config(UserDict):
 
         self.data[CONFIG_SECTION] = self.data.get(CONFIG_SECTION, []) + config_settings
 
-    def _find_config_setting(self, predicate: Callable) -> Any:
-        """Find a config setting based on `predicate`.
+    def _find_first_config_setting(self, predicate: Callable) -> Any:
+        """Find first config setting based on `predicate`.
 
         `predicate` is a callable that gets a config setting passed in as an argument. This callable must define the
         condition for identifying a config setting.
 
         Example:
-            The following call will find a ConfigSetting whose name is "foo":
+            The following call will find the first ConfigSetting whose name is "foo":
             `config._find_config_setting(lambda x: x.name == "foo")`
 
         Args:

--- a/tests/build/_internal/config/test_config.py
+++ b/tests/build/_internal/config/test_config.py
@@ -111,11 +111,12 @@ class TestConfig:
 
         assert conf["macros"] == {"A", "B"}
 
-    def test_raises_when_override_not_already_defined(self):
+    def test_warns_and_skips_override_for_undefined_config_parameter(self, caplog):
         conf = Config()
-
-        with pytest.raises(ValueError):
-            conf.update(prepare({"target_overrides": {"*": {"this-does-not-exist": ""}}}))
+        override_name = "this-does-not-exist"
+        conf.update(prepare({"target_overrides": {"*": {override_name: ""}}}))
+        assert override_name in caplog.text
+        assert not conf
 
     def test_ignores_present_option(self):
         source = prepare({"name": "mbed_component", "config": {"present": {"help": "Mbed Component", "value": True}}})

--- a/tests/build/test_generate_config.py
+++ b/tests/build/test_generate_config.py
@@ -385,14 +385,14 @@ def test_target_list_params_can_be_removed(
     assert expected_output not in config_text
 
 
-def test_raises_when_attempting_to_override_nonexistent_param(matching_target_and_filter, program):
+def test_warns_when_attempting_to_override_nonexistent_param(matching_target_and_filter, program, caplog):
     target, target_filter = matching_target_and_filter
-    create_mbed_app_json(
-        program.root, target_overrides={target_filter: {"target.some-nonexistent-config-param": 999999}}
-    )
+    override_name = "target.some-nonexistent-config-param"
+    create_mbed_app_json(program.root, target_overrides={target_filter: {override_name: 999999}})
 
-    with pytest.raises(ValueError):
-        generate_config(target, "GCC_ARM", program)
+    generate_config(target, "GCC_ARM", program)
+
+    assert override_name in caplog.text
 
 
 def test_settings_from_multiple_libs_included(matching_target_and_filter, program):


### PR DESCRIPTION
### Description

<!--
Please add any detail or context that would be useful to a reviewer.
-->
To keep backwards compatibility we now just emit a warning message when the user provides an invalid `target_override`.


### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [x]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
