### PR TITLE
config: Pass mbed-os-path to generate_config

### DIFF
--- a/news/20210302104001.bugfix
+++ b/news/20210302104001.bugfix
@@ -1,0 +1,1 @@
+Search mbed-os for config files when mbed-os-path is used and mbed-os is not a subdirectory of the project.

--- a/src/mbed_tools/build/config.py
+++ b/src/mbed_tools/build/config.py
@@ -31,7 +31,9 @@ def generate_config(target_name: str, toolchain: str, program: MbedProgram) -> p
     """
     targets_data = _load_raw_targets_data(program)
     target_build_attributes = get_target_by_name(target_name, targets_data)
-    config = assemble_config(target_build_attributes, program.root, program.files.app_config_file)
+    config = assemble_config(
+        target_build_attributes, [program.root, program.mbed_os.root], program.files.app_config_file
+    )
     cmake_file_contents = render_mbed_config_cmake_template(
         target_name=target_name, config=config, toolchain_name=toolchain,
     )


### PR DESCRIPTION
Previously the mbed-os-path wasn't being passed to assemble_config.
This meant if mbed-os was in a directory above the project root no
mbed_lib.json files would be detected as assemble_config was always
searching for mbed_lib.json files from the project root down.

This commit modifies assemble_config to take an iterable of search
paths it will scan for config files.

Fixes #204

### Description

<!--
Please add any detail or context that would be useful to a reviewer.
-->



### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [x]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
