### PR TITLE
Add support for using unknown boards without access to the online database

### DIFF
--- a/news/201.bugfix
+++ b/news/201.bugfix
@@ -1,0 +1,1 @@
+Define a board as unknown if it cannot be identified locally when unable to access the online database.

--- a/src/mbed_tools/targets/_internal/board_database.py
+++ b/src/mbed_tools/targets/_internal/board_database.py
@@ -106,5 +106,5 @@ def _get_request() -> requests.Response:
     try:
         return requests.get(_BOARD_API, headers=header)
     except requests.exceptions.ConnectionError as connection_error:
-        logger.warning("There was an error connecting to the online database. Please check your internet connection.")
+        logger.warning("Unable to connect to the online database. Please check your internet connection.")
         raise BoardAPIError("Failed to connect to the online database.") from connection_error

--- a/src/mbed_tools/targets/get_board.py
+++ b/src/mbed_tools/targets/get_board.py
@@ -11,7 +11,7 @@ from enum import Enum
 from typing import Callable
 
 from mbed_tools.targets.env import env
-from mbed_tools.targets.exceptions import UnknownBoard, UnsupportedMode
+from mbed_tools.targets.exceptions import UnknownBoard, UnsupportedMode, BoardDatabaseError
 from mbed_tools.targets.board import Board
 from mbed_tools.targets.boards import Boards
 
@@ -70,7 +70,11 @@ def get_board(matching: Callable) -> Board:
         return Boards.from_offline_database().get_board(matching)
     except UnknownBoard:
         logger.info("Unable to identify a board using the offline database, trying the online database.")
-        return Boards.from_online_database().get_board(matching)
+        try:
+            return Boards.from_online_database().get_board(matching)
+        except BoardDatabaseError:
+            logger.error("Unable to access the online database to identify a board.")
+            raise UnknownBoard()
 
 
 class _DatabaseMode(Enum):


### PR DESCRIPTION
### Description


Previously if a board could not be identified with the offline database, and the online database could not be accessed, the command would fail. Instead, now a clearer error message will be logged and the board will be considered as an unknown board, allowing it to be found with `detect` regardless of network connection.

Example:
```
$ mbed-tools detect -a
ERROR: Unable to access the online database to identify a board.
ERROR: Could not identify a board with the product code: '0799'.
Board name    Serial number             Serial port    Mount point(s)             Build target(s)
------------  ------------------------  -------------  -------------------------  -----------------
<unknown>     0674FF504955857567165732  /dev/ttyACM0   /media/werner/NODE_L4R5ZI
```

Fixes #201

### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [x]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
