### PR TITLE
targets: Improve error messaging on invalid target override

### DIFF
--- a/news/20210303115502.bugfix
+++ b/news/20210303115502.bugfix
@@ -1,0 +1,1 @@
+Improve error messaging in targets module when an invalid override is detected.

--- a/src/mbed_tools/targets/_internal/target_attributes.py
+++ b/src/mbed_tools/targets/_internal/target_attributes.py
@@ -7,6 +7,7 @@
 This information is parsed from the targets.json configuration file
 found in the mbed-os repo.
 """
+import logging
 import pathlib
 from typing import Dict, Any, Set, Optional
 
@@ -20,10 +21,11 @@ from mbed_tools.targets._internal.targets_json_parsers.overriding_attribute_pars
     get_overriding_attributes_for_target,
     get_labels_for_target,
 )
-from mbed_tools.targets._internal.exceptions import TargetsJsonConfigurationError
 
 INTERNAL_PACKAGE_DIR = pathlib.Path(__file__).parent
 MBED_OS_METADATA_FILE = pathlib.Path(INTERNAL_PACKAGE_DIR, "data", "targets_metadata.json")
+
+logger = logging.getLogger(__name__)
 
 
 class TargetAttributesError(ToolsError):
@@ -126,5 +128,7 @@ def _apply_config_overrides(config: Dict[str, Any], overrides: Dict[str, Any]) -
         try:
             config[key]["value"] = overrides[key]
         except KeyError:
-            raise TargetsJsonConfigurationError("Cannot override config setting that is not defined.")
+            logger.warning(
+                f"Cannot apply override {key}={overrides[key]}, there is no config setting defined matching that name."
+            )
     return config

--- a/tests/targets/_internal/test_target_attributes.py
+++ b/tests/targets/_internal/test_target_attributes.py
@@ -5,7 +5,6 @@
 """Tests for `mbed_tools.targets.target_attributes`."""
 from unittest import TestCase, mock
 
-from mbed_tools.targets._internal.exceptions import TargetsJsonConfigurationError
 from mbed_tools.targets._internal.target_attributes import (
     TargetNotFoundError,
     get_target_attributes,
@@ -109,8 +108,11 @@ class TestApplyConfigOverrides(TestCase):
 
         self.assertEqual(config, _apply_config_overrides(config, overrides))
 
-    def test_overriding_non_existing_config(self):
+    def test_warns_when_attempting_to_override_undefined_config_parameter(self):
         config = {"foo": {"help": "Do a foo", "value": 0}}
         overrides = {"bar": 9}
-        with self.assertRaises(TargetsJsonConfigurationError):
+
+        with self.assertLogs(level="WARNING") as logger:
             _apply_config_overrides(config, overrides)
+
+        self.assertIn("bar=9", logger.output[0])


### PR DESCRIPTION
The targets module has its own mechanism for handling configuration
overrides when parsing targets.json. Improve the error messaging when an
invalid override is encountered and change the error into a warning.

### Description

<!--
Please add any detail or context that would be useful to a reviewer.
-->



### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [x]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
