### PR TITLE
targets: Improve logging with requests.get

### DIFF
--- a/news/20210304131741.bugfix
+++ b/news/20210304131741.bugfix
@@ -1,0 +1,1 @@
+Improve error messaging when unable to access the online database.

--- a/src/mbed_tools/targets/_internal/board_database.py
+++ b/src/mbed_tools/targets/_internal/board_database.py
@@ -106,5 +106,10 @@ def _get_request() -> requests.Response:
     try:
         return requests.get(_BOARD_API, headers=header)
     except requests.exceptions.ConnectionError as connection_error:
+        if isinstance(connection_error, requests.exceptions.SSLError):
+            logger.warning("Unable to verify an SSL certificate with requests.")
+        elif isinstance(connection_error, requests.exceptions.ProxyError):
+            logger.warning("Failed to connect to proxy. Please check your proxy configuration.")
+
         logger.warning("Unable to connect to the online database. Please check your internet connection.")
         raise BoardAPIError("Failed to connect to the online database.") from connection_error

--- a/tests/targets/_internal/test_board_database.py
+++ b/tests/targets/_internal/test_board_database.py
@@ -91,6 +91,22 @@ class TestGetOnlineBoardData(TestCase):
         with self.assertRaises(board_database.BoardAPIError):
             board_database._get_request()
 
+    @mock.patch("mbed_tools.targets._internal.board_database.logger.warning", autospec=True)
+    @mock.patch("mbed_tools.targets._internal.board_database.requests.get")
+    def test_logs_error_on_requests_ssl_error(self, get, logger_warning):
+        get.side_effect = board_database.requests.exceptions.SSLError
+        with self.assertRaises(board_database.BoardAPIError):
+            board_database._get_request()
+        self.assertTrue("verify an SSL" in str(logger_warning.call_args_list))
+
+    @mock.patch("mbed_tools.targets._internal.board_database.logger.warning", autospec=True)
+    @mock.patch("mbed_tools.targets._internal.board_database.requests.get")
+    def test_logs_error_on_requests_proxy_error(self, get, logger_warning):
+        get.side_effect = board_database.requests.exceptions.ProxyError
+        with self.assertRaises(board_database.BoardAPIError):
+            board_database._get_request()
+        self.assertTrue("connect to proxy" in str(logger_warning.call_args_list))
+
 
 class TestGetOfflineTargetData(TestCase):
     """Tests for the method get_offline_target_data."""


### PR DESCRIPTION
### Description

Previously when accessing the board database failed, any `ConnectionError` raised would give the same log message, giving little information about the cause. Additional warning logs are added for two subclasses, `SSLError` and `ProxyError` for more user-friendly information.


### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [x]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
