### PR TITLE
tests: Add cases for board database requests

### DIFF
--- a/news/200.misc
+++ b/news/200.misc
@@ -1,0 +1,1 @@
+Add tests for proxy support when reading the online board database.

--- a/tests/targets/_internal/test_board_database.py
+++ b/tests/targets/_internal/test_board_database.py
@@ -4,71 +4,75 @@
 #
 """Tests for `mbed_tools.targets._internal.board_database`."""
 
-from unittest import TestCase, mock
+from unittest import mock
 
-import requests_mock
+import logging
+import pytest
 
-# Unit under test
 import mbed_tools.targets._internal.board_database as board_database
 from mbed_tools.targets.env import env
 
 
-class TestGetOnlineBoardData(TestCase):
+class TestGetOnlineBoardData:
     """Tests for the method `board_database.get_online_board_data`."""
 
-    @requests_mock.mock()
-    @mock.patch("mbed_tools.targets._internal.board_database.logger.warning", autospec=True)
-    @mock.patch("mbed_tools.targets._internal.board_database.logger.debug", autospec=True)
-    def test_401(self, mock_request, logger_debug, logger_warning):
+    def test_401(self, caplog, requests_mock):
         """Given a 401 error code, BoardAPIError is raised."""
-        mock_request.get(board_database._BOARD_API, status_code=401, text="Who are you?")
-        with self.assertRaises(board_database.BoardAPIError):
+        caplog.set_level(logging.DEBUG)
+        requests_mock.get(board_database._BOARD_API, status_code=401, text="Who are you?")
+        with pytest.raises(board_database.BoardAPIError):
             board_database.get_online_board_data()
-        self.assertTrue("MBED_API_AUTH_TOKEN" in str(logger_warning.call_args), "Auth token should be mentioned")
-        self.assertTrue("Who are you?" in str(logger_debug.call_args), "Message content should be in the debug message")
+        assert any(
+            x for x in caplog.records if x.levelno == logging.WARNING and "MBED_API_AUTH_TOKEN" in x.msg
+        ), "Auth token should be mentioned"
+        assert any(
+            x for x in caplog.records if x.levelno == logging.DEBUG and "Who are you?" in x.msg
+        ), "Message content should be in the debug message"
 
-    @requests_mock.mock()
-    @mock.patch("mbed_tools.targets._internal.board_database.logger.warning", autospec=True)
-    @mock.patch("mbed_tools.targets._internal.board_database.logger.debug", autospec=True)
-    def test_404(self, mock_request, logger_debug, logger_warning):
+    def test_404(self, caplog, requests_mock):
         """Given a 404 error code, TargetAPIError is raised."""
-        mock_request.get(board_database._BOARD_API, status_code=404, text="Not Found")
-        with self.assertRaises(board_database.BoardAPIError):
+        caplog.set_level(logging.DEBUG)
+        requests_mock.get(board_database._BOARD_API, status_code=404, text="Not Found")
+        with pytest.raises(board_database.BoardAPIError):
             board_database.get_online_board_data()
-        self.assertTrue("404" in str(logger_warning.call_args), "HTTP status code should be mentioned")
-        self.assertTrue("Not Found" in str(logger_debug.call_args), "Message content should be in the debug message")
+        assert any(
+            x for x in caplog.records if x.levelno == logging.WARNING and "404" in x.msg
+        ), "HTTP status code should be mentioned"
+        assert any(
+            x for x in caplog.records if x.levelno == logging.DEBUG and "Not Found" in x.msg
+        ), "Message content should be in the debug message"
 
-    @requests_mock.mock()
-    @mock.patch("mbed_tools.targets._internal.board_database.logger.warning", autospec=True)
-    @mock.patch("mbed_tools.targets._internal.board_database.logger.debug", autospec=True)
-    def test_200_invalid_json(self, mock_request, logger_debug, logger_warning):
+    def test_200_invalid_json(self, caplog, requests_mock):
         """Given a valid response but invalid json, JSONDecodeError is raised."""
-        mock_request.get(board_database._BOARD_API, text="some text")
-        with self.assertRaises(board_database.ResponseJSONError):
+        caplog.set_level(logging.DEBUG)
+        requests_mock.get(board_database._BOARD_API, text="some text")
+        with pytest.raises(board_database.ResponseJSONError):
             board_database.get_online_board_data()
-        self.assertTrue("Invalid JSON" in str(logger_warning.call_args), "Invalid JSON should be mentioned")
-        self.assertTrue("some text" in str(logger_debug.call_args), "Message content should be in the debug message")
+        assert any(
+            x for x in caplog.records if x.levelno == logging.WARNING and "Invalid JSON" in x.msg
+        ), "Invalid JSON should be mentioned"
+        assert any(
+            x for x in caplog.records if x.levelno == logging.DEBUG and "some text" in x.msg
+        ), "Message content should be in the debug message"
 
-    @requests_mock.mock()
-    @mock.patch("mbed_tools.targets._internal.board_database.logger.warning", autospec=True)
-    @mock.patch("mbed_tools.targets._internal.board_database.logger.debug", autospec=True)
-    def test_200_no_data_field(self, mock_request, logger_debug, logger_warning):
+    def test_200_no_data_field(self, caplog, requests_mock):
         """Given a valid response but no data field, ResponseJSONError is raised."""
-        mock_request.get(board_database._BOARD_API, json={"notdata": [], "stillnotdata": {}})
-        with self.assertRaises(board_database.ResponseJSONError):
+        caplog.set_level(logging.DEBUG)
+        requests_mock.get(board_database._BOARD_API, json={"notdata": [], "stillnotdata": {}})
+        with pytest.raises(board_database.ResponseJSONError):
             board_database.get_online_board_data()
-        self.assertTrue("missing the 'data' field" in str(logger_warning.call_args), "Data field should be mentioned")
-        self.assertTrue(
-            "notdata, stillnotdata" in str(logger_debug.call_args),
-            "JSON keys from message should be in the debug message",
-        )
+        assert any(
+            x for x in caplog.records if x.levelno == logging.WARNING and "missing the 'data' field" in x.msg
+        ), "Data field should be mentioned"
+        assert any(
+            x for x in caplog.records if x.levelno == logging.DEBUG and "notdata, stillnotdata" in x.msg
+        ), "JSON keys from message should be in the debug message"
 
-    @requests_mock.mock()
-    def test_200_value_data(self, mock_request):
+    def test_200_value_data(self, requests_mock):
         """Given a valid response, target data is set from the returned json."""
-        mock_request.get(board_database._BOARD_API, json={"data": 42})
+        requests_mock.get(board_database._BOARD_API, json={"data": 42})
         board_data = board_database.get_online_board_data()
-        self.assertEqual(42, board_data, "Target data should match the contents of the target API data")
+        assert 42 == board_data, "Target data should match the contents of the target API data"
 
     @mock.patch("mbed_tools.targets._internal.board_database.requests")
     @mock.patch("mbed_tools.targets._internal.board_database.env", spec_set=env)
@@ -88,33 +92,31 @@ class TestGetOnlineBoardData(TestCase):
     @mock.patch("mbed_tools.targets._internal.board_database.requests.get")
     def test_raises_tools_error_on_connection_error(self, get):
         get.side_effect = board_database.requests.exceptions.ConnectionError
-        with self.assertRaises(board_database.BoardAPIError):
+        with pytest.raises(board_database.BoardAPIError):
             board_database._get_request()
 
-    @mock.patch("mbed_tools.targets._internal.board_database.logger.warning", autospec=True)
     @mock.patch("mbed_tools.targets._internal.board_database.requests.get")
-    def test_logs_error_on_requests_ssl_error(self, get, logger_warning):
+    def test_logs_error_on_requests_ssl_error(self, get, caplog):
         get.side_effect = board_database.requests.exceptions.SSLError
-        with self.assertRaises(board_database.BoardAPIError):
+        with pytest.raises(board_database.BoardAPIError):
             board_database._get_request()
-        self.assertTrue("verify an SSL" in str(logger_warning.call_args_list))
+        assert "verify an SSL" in caplog.text
 
-    @mock.patch("mbed_tools.targets._internal.board_database.logger.warning", autospec=True)
     @mock.patch("mbed_tools.targets._internal.board_database.requests.get")
-    def test_logs_error_on_requests_proxy_error(self, get, logger_warning):
+    def test_logs_error_on_requests_proxy_error(self, get, caplog):
         get.side_effect = board_database.requests.exceptions.ProxyError
-        with self.assertRaises(board_database.BoardAPIError):
+        with pytest.raises(board_database.BoardAPIError):
             board_database._get_request()
-        self.assertTrue("connect to proxy" in str(logger_warning.call_args_list))
+        assert "connect to proxy" in caplog.text
 
 
-class TestGetOfflineTargetData(TestCase):
+class TestGetOfflineTargetData:
     """Tests for the method get_offline_target_data."""
 
     def test_local_target_database_file_found(self):
         """Test local database is found and loaded."""
         data = board_database.get_offline_board_data()
-        self.assertTrue(len(data), "Some data should be returned from local database file.")
+        assert len(data), "Some data should be returned from local database file."
 
     @mock.patch("mbed_tools.targets._internal.board_database.get_board_database_path")
     def test_raises_on_invalid_json(self, mocked_get_file):
@@ -123,11 +125,11 @@ class TestGetOfflineTargetData(TestCase):
         path_mock = mock.Mock()
         path_mock.read_text.return_value = invalid_json
         mocked_get_file.return_value = path_mock
-        with self.assertRaises(board_database.ResponseJSONError):
+        with pytest.raises(board_database.ResponseJSONError):
             board_database.get_offline_board_data()
 
 
-class TestGetLocalTargetDatabaseFile(TestCase):
+class TestGetLocalTargetDatabaseFile:
     def test_returns_path_to_targets(self):
         path = board_database.get_board_database_path()
-        self.assertEqual(path.exists(), True, "Path to boards should exist in the package data folder.")
+        assert path.exists(), "Path to boards should exist in the package data folder."

--- a/tests/targets/_internal/test_board_database.py
+++ b/tests/targets/_internal/test_board_database.py
@@ -90,10 +90,17 @@ class TestGetOnlineBoardData:
         requests.get.assert_called_once_with(board_database._BOARD_API, headers=None)
 
     @mock.patch("mbed_tools.targets._internal.board_database.requests.get")
-    def test_raises_tools_error_on_connection_error(self, get):
+    def test_logs_no_warning_on_success(self, get, caplog):
+        board_database._get_request()
+        assert not caplog.records
+
+    @mock.patch("mbed_tools.targets._internal.board_database.requests.get")
+    def test_raises_tools_error_on_connection_error(self, get, caplog):
         get.side_effect = board_database.requests.exceptions.ConnectionError
         with pytest.raises(board_database.BoardAPIError):
             board_database._get_request()
+        assert "Unable to connect" in caplog.text
+        assert len(caplog.records) == 1
 
     @mock.patch("mbed_tools.targets._internal.board_database.requests.get")
     def test_logs_error_on_requests_ssl_error(self, get, caplog):

--- a/tests/targets/_internal/test_board_database.py
+++ b/tests/targets/_internal/test_board_database.py
@@ -116,6 +116,18 @@ class TestGetOnlineBoardData:
             board_database._get_request()
         assert "connect to proxy" in caplog.text
 
+    @mock.patch.dict("os.environ", {"http_proxy": "http://proxy:8080", "https_proxy": "https://proxy:8080"})
+    def test_requests_uses_proxy_variables(self, requests_mock):
+        requests_mock.get(board_database._BOARD_API)
+        board_database._get_request()
+        assert requests_mock.last_request.proxies == {"http": "http://proxy:8080", "https": "https://proxy:8080"}
+
+    @mock.patch.dict("os.environ", {"http_proxy": "http://proxy:8080", "https_proxy": "https://proxy:8080"})
+    def test_raises_proxy_error_with_invalid_proxy(self, caplog):
+        with pytest.raises(board_database.BoardAPIError):
+            board_database._get_request()
+        assert "connect to proxy" in caplog.text
+
 
 class TestGetOfflineTargetData:
     """Tests for the method get_offline_target_data."""


### PR DESCRIPTION
### Description

To make sure we're supporting proxies, test cases are added to check that `http_proxy` and `https_proxy` will be read from when accessing the online board database.

Tests are also added to improve coverage with the board database request code, to make sure that the correct warnings are being logged.

### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [x]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
