### PR TITLE
Revert "Add some mbed-os dependencies as our own"

### DIFF
--- a/news/171.bugfix
+++ b/news/171.bugfix
@@ -1,0 +1,1 @@
+Remove Mbed OS's Python dependencies as they are now optional within Mbed OS.

--- a/setup.py
+++ b/setup.py
@@ -50,12 +50,6 @@ setup(
         "typing-extensions",
         "Jinja2",
         "pyserial",
-        # Mbed OS 6.7 dependencies
-        # TODO Remove these as part of fixing
-        # https://github.com/ARMmbed/mbed-tools/issues/171
-        "prettytable",
-        "intelhex",
-        "future",
     ],
     license="Apache 2.0",
     long_description_content_type="text/markdown",


### PR DESCRIPTION


### Description

<!--
Please add any detail or context that would be useful to a reviewer.
-->

This reverts commit b8701297370e4768bc8b7f4e6bab1430eba81689.

Mbed OS has made these dependencies optional. Mbed OS CMake will try to
detect if they are present before using them, displaying a warning if
they are not available. As such, it no longer helps Mbed usability to
have mbed-tools depend on these dependencies it doesn't need. Remove
mbed-os dependencies, which are now optional, from mbed-tools.

Fixes #171

### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [X]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
