### PR TITLE
devices: Improve obtuse error message

### DIFF
--- a/news/229.bugfix
+++ b/news/229.bugfix
@@ -1,0 +1,1 @@
+Improve error message when we fail to find a valid product code in a connected device's HTM file.

--- a/src/mbed_tools/devices/devices.py
+++ b/src/mbed_tools/devices/devices.py
@@ -36,7 +36,12 @@ def get_connected_devices() -> ConnectedDevices:
         except NoBoardForCandidate:
             board = None
         except MbedTargetsError as err:
-            raise DeviceLookupFailed("A problem occurred when looking up board data for connected devices.") from err
+            raise DeviceLookupFailed(
+                f"We found a potential connected device ({candidate_device!r}) but could not identify it as being "
+                "Mbed enabled. This is because we couldn't find a known product code from the available data on your "
+                "device. Check your device contains a valid HTM file with a product code, and that it is added as an "
+                "Mbed enabled device on os.mbed.com."
+            ) from err
 
         connected_devices.add_device(candidate_device, board)
 


### PR DESCRIPTION
### Description

We used to emit the somewhat enigmatic phrase "There was a problem
detecting your board" when we fail to find a "product code" in the
devices HTM file that matches an entry in the database. Instead of
expecting our users to have a level of deductive reasoning bordering on
the supernatural, actually produce an error message that might help
them in debugging the problem.

Fixes #229 


<!--
Please add any detail or context that would be useful to a reviewer.
-->



### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [ ]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [x]  Additional tests are not required for this change (e.g. documentation update).
