### PR TITLE
tests: Remove redundant board db proxy test

### DIFF
--- a/news/20210312114544.misc
+++ b/news/20210312114544.misc
@@ -1,0 +1,1 @@
+Remove redundant test of proxy support in test_board_database.

--- a/tests/targets/_internal/test_board_database.py
+++ b/tests/targets/_internal/test_board_database.py
@@ -122,12 +122,6 @@ class TestGetOnlineBoardData:
         board_database._get_request()
         assert requests_mock.last_request.proxies == {"http": "http://proxy:8080", "https": "https://proxy:8080"}
 
-    @mock.patch.dict("os.environ", {"http_proxy": "http://proxy:8080", "https_proxy": "https://proxy:8080"})
-    def test_raises_proxy_error_with_invalid_proxy(self, caplog):
-        with pytest.raises(board_database.BoardAPIError):
-            board_database._get_request()
-        assert "connect to proxy" in caplog.text
-
 
 class TestGetOfflineTargetData:
     """Tests for the method get_offline_target_data."""


### PR DESCRIPTION
### Description

When adding tests for proxy support, a test was added which uses `requests` with a non-existent proxy. This is effectively a test of `requests`, rather than a unit test of `mbed-tools`, and is redundant as other tests cover this proxy error using mocks.

### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [x]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
