### PR TITLE
ci: travis: Remove deprecated config option from custom_targets.json

### DIFF
--- a/news/20210323151402.misc
+++ b/news/20210323151402.misc
@@ -1,0 +1,1 @@
+Update form factor ARDUINO to ARDUINO_UNO in the custom targets travis test as ARDUINO has been deprecated.

--- a/travis-ci/test-data/custom_targets.json
+++ b/travis-ci/test-data/custom_targets.json
@@ -12,7 +12,7 @@
             "MX25R6435F"
         ],
         "supported_form_factors": [
-            "ARDUINO"
+            "ARDUINO_UNO"
         ],
         "detect_code": [
             "1234"


### PR DESCRIPTION
### Description

Form factor ARDUINO has been deprecated and replaced with ARDUINO_UNO.
Update the form factor in our custom_targets.json for the custom target
integration test in travis.



<!--
Please add any detail or context that would be useful to a reviewer.
-->



### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [x]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
