### PR TITLE
config: Add `OUTPUT_EXT`

### DIFF
--- a/news/216.bugfix
+++ b/news/216.bugfix
@@ -1,0 +1,1 @@
+Add a CMake variable `MBED_OUTPUT_EXT` for the output image extension.

--- a/src/mbed_tools/build/_internal/templates/mbed_config.tmpl
+++ b/src/mbed_tools/build/_internal/templates/mbed_config.tmpl
@@ -9,6 +9,7 @@ set(MBED_TARGET "{{target_name}}" CACHE STRING "")
 set(MBED_CPU_CORE "{{core}}" CACHE STRING "")
 set(MBED_C_LIB "{{c_lib}}" CACHE STRING "")
 set(MBED_PRINTF_LIB "{{printf_lib}}" CACHE STRING "")
+set(MBED_OUTPUT_EXT "{{OUTPUT_EXT}}" CACHE STRING "")
 
 list(APPEND MBED_TARGET_SUPPORTED_C_LIBS {% for supported_c_lib in supported_c_libs %}
     {{supported_c_lib}}

--- a/tests/build/test_generate_config.py
+++ b/tests/build/test_generate_config.py
@@ -47,6 +47,7 @@ TARGET_DATA = {
     "supported_form_factors": ["ARDUINO"],
     "supported_toolchains": ["ARM", "GCC_ARM", "IAR"],
     "trustzone": False,
+    "OUTPUT_EXT": "hex",
 }
 
 
@@ -288,6 +289,7 @@ def test_overrides_target_config_param_from_app(matching_target_and_filter, prog
         ("target.macros", ["DEFINE"], "DEFINE"),
         ("target.device_has", ["NOTHING"], "DEVICE_NOTHING"),
         ("target.features", ["ELECTRICITY"], "FEATURE_ELECTRICITY"),
+        ("OUTPUT_EXT", "hex", 'MBED_OUTPUT_EXT "hex"'),
     ],
 )
 def test_overrides_target_non_config_params_from_app(


### PR DESCRIPTION
### Description

<!--
Please add any detail or context that would be useful to a reviewer.
-->

Fixes: #216 

The optional `OUTPUT_EXT` field in Mbed OS `targets.json` specifies the format of the output image. This is important because
* some targets only support one image format
* each post-binary hook outputs one image only

This avoids confusion of having both .hex and .bin images generated while only one of them is usable.

Note: The CMake change in Mbed OS is https://github.com/ARMmbed/mbed-os/pull/14472

### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [x]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
