### PR TITLE
setup: Relax Click version requirement

### DIFF
--- a/news/245.bugfix
+++ b/news/245.bugfix
@@ -1,0 +1,1 @@
+Unpin Click version to minimise the potential for dependency conflicts with other packages.

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(
     include_package_data=True,
     install_requires=[
         "python-dotenv",
-        "Click==7.1",
+        "Click>=7.1,<8",
         "pdoc3",
         "GitPython",
         "tqdm",


### PR DESCRIPTION
### Description

We were pinning the version of Click we depend on to 7.1. Pinning to a
specific version of the package is not ideal, as we would have to keep
updating the pinned version to avoid dependency conflicts with newer
Python packages that depend on later versions of Click. We depend on
some Click features that appeared in 7.1, so we do need at least this
version. Later versions of the package should also work for us, so we
don't need to specify the requirement so precisely.

This commit relaxes the requirement to Click 7.1 or greater. This should
minimise the potential for dependency conflicts with other packages.

Fixes #245 

<!--
Please add any detail or context that would be useful to a reviewer.
-->



### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [x]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
