### PR TITLE
devices: Detect and extract data from J-Link

### DIFF
--- a/news/20210330104425.feature
+++ b/news/20210330104425.feature
@@ -1,0 +1,1 @@
+Add detection of devices connected with J-Link.

--- a/src/mbed_tools/devices/_internal/resolve_board.py
+++ b/src/mbed_tools/devices/_internal/resolve_board.py
@@ -13,7 +13,12 @@ import logging
 
 from typing import Optional
 
-from mbed_tools.targets import Board, get_board_by_product_code, get_board_by_online_id
+from mbed_tools.targets import (
+    Board,
+    get_board_by_product_code,
+    get_board_by_online_id,
+    get_board_by_jlink_slug,
+)
 from mbed_tools.targets.exceptions import UnknownBoard, MbedTargetsError
 
 from mbed_tools.devices._internal.exceptions import NoBoardForCandidate, ResolveBoardError
@@ -36,7 +41,7 @@ def resolve_board(
     The rules are as follows:
 
     1. Use the product code from the mbed.htm file or details.txt if available
-    2. Use online ID from the htm file if available
+    2. Use online ID from the htm file or Board.html if available
     3. Try to use the first 4 chars of the USB serial number as the product code
     """
     if product_code:
@@ -54,7 +59,10 @@ def resolve_board(
         slug = online_id.slug
         target_type = online_id.target_type
         try:
-            return get_board_by_online_id(slug=slug, target_type=target_type)
+            if target_type == "jlink":
+                return get_board_by_jlink_slug(slug=slug)
+            else:
+                return get_board_by_online_id(slug=slug, target_type=target_type)
         except UnknownBoard:
             logger.error(f"Could not identify a board with the slug: '{slug}' and target type: '{target_type}'.")
         except MbedTargetsError as e:

--- a/src/mbed_tools/targets/__init__.py
+++ b/src/mbed_tools/targets/__init__.py
@@ -28,5 +28,6 @@ from mbed_tools.targets.get_target import (
 from mbed_tools.targets.get_board import (
     get_board_by_product_code,
     get_board_by_online_id,
+    get_board_by_jlink_slug,
 )
 from mbed_tools.targets.board import Board

--- a/src/mbed_tools/targets/get_board.py
+++ b/src/mbed_tools/targets/get_board.py
@@ -45,6 +45,25 @@ def get_board_by_online_id(slug: str, target_type: str) -> Board:
     return get_board(lambda board: board.slug.casefold() == matched_slug and board.target_type == target_type)
 
 
+def get_board_by_jlink_slug(slug: str) -> Board:
+    """Returns first `mbed-tools.targets.board.Board` matching given slug.
+
+    With J-Link, the slug is extracted from a board manufacturer URL, and may not match
+    the Mbed slug. The J-Link slug is compared against the slug, board_name and
+    board_type of entries in the board database until a match is found.
+
+    Args:
+        slug: the J-Link slug to look up in the database.
+
+    Raises:
+        UnknownBoard: a board matching the slug was not found.
+    """
+    matched_slug = slug.casefold()
+    return get_board(
+        lambda board: any(matched_slug == c.casefold() for c in [board.slug, board.board_name, board.board_type])
+    )
+
+
 def get_board(matching: Callable) -> Board:
     """Returns first `mbed_tools.targets.board.Board` for which `matching` is True.
 

--- a/tests/targets/test_get_board.py
+++ b/tests/targets/test_get_board.py
@@ -3,7 +3,9 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 """Tests for `mbed_tools.targets.get_board`."""
-from unittest import mock, TestCase
+import pytest
+
+from unittest import mock
 
 from mbed_tools.targets._internal.exceptions import BoardAPIError
 
@@ -19,66 +21,81 @@ from mbed_tools.targets.exceptions import UnknownBoard, UnsupportedMode
 from tests.targets.factories import make_board
 
 
-@mock.patch("mbed_tools.targets.get_board.Boards", autospec=True)
-@mock.patch("mbed_tools.targets.get_board.env", spec_set=env)
-class TestGetBoard(TestCase):
-    def test_online_mode(self, env, mocked_boards):
-        env.MBED_DATABASE_MODE = "ONLINE"
+@pytest.fixture
+def mock_get_board():
+    with mock.patch("mbed_tools.targets.get_board.get_board", autospec=True) as gbp:
+        yield gbp
+
+
+@pytest.fixture
+def mock_env():
+    with mock.patch("mbed_tools.targets.get_board.env", spec_set=env) as gbp:
+        yield gbp
+
+
+@pytest.fixture
+def mocked_boards():
+    with mock.patch("mbed_tools.targets.get_board.Boards", autospec=True) as gbp:
+        yield gbp
+
+
+class TestGetBoard:
+    def test_online_mode(self, mock_env, mocked_boards):
+        mock_env.MBED_DATABASE_MODE = "ONLINE"
         fn = mock.Mock()
 
         subject = get_board(fn)
 
-        self.assertEqual(subject, mocked_boards.from_online_database().get_board.return_value)
+        assert subject == mocked_boards.from_online_database().get_board.return_value
         mocked_boards.from_online_database().get_board.assert_called_once_with(fn)
 
-    def test_offline_mode(self, env, mocked_boards):
-        env.MBED_DATABASE_MODE = "OFFLINE"
+    def test_offline_mode(self, mock_env, mocked_boards):
+        mock_env.MBED_DATABASE_MODE = "OFFLINE"
         fn = mock.Mock()
 
         subject = get_board(fn)
 
-        self.assertEqual(subject, mocked_boards.from_offline_database().get_board.return_value)
+        assert subject == mocked_boards.from_offline_database().get_board.return_value
         mocked_boards.from_offline_database().get_board.assert_called_once_with(fn)
 
-    def test_auto_mode_calls_offline_boards_first(self, env, mocked_boards):
-        env.MBED_DATABASE_MODE = "AUTO"
+    def test_auto_mode_calls_offline_boards_first(self, mock_env, mocked_boards):
+        mock_env.MBED_DATABASE_MODE = "AUTO"
         fn = mock.Mock()
 
         subject = get_board(fn)
 
-        self.assertEqual(subject, mocked_boards.from_offline_database().get_board.return_value)
+        assert subject == mocked_boards.from_offline_database().get_board.return_value
         mocked_boards.from_online_database().get_board.assert_not_called()
         mocked_boards.from_offline_database().get_board.assert_called_once_with(fn)
 
-    def test_auto_mode_falls_back_to_online_database_when_board_not_found(self, env, mocked_boards):
-        env.MBED_DATABASE_MODE = "AUTO"
+    def test_auto_mode_falls_back_to_online_database_when_board_not_found(self, mock_env, mocked_boards):
+        mock_env.MBED_DATABASE_MODE = "AUTO"
         mocked_boards.from_offline_database().get_board.side_effect = UnknownBoard
         fn = mock.Mock()
 
         subject = get_board(fn)
 
-        self.assertEqual(subject, mocked_boards.from_online_database().get_board.return_value)
+        assert subject == mocked_boards.from_online_database().get_board.return_value
         mocked_boards.from_offline_database().get_board.assert_called_once_with(fn)
         mocked_boards.from_online_database().get_board.assert_called_once_with(fn)
 
-    def test_auto_mode_raises_when_board_not_found_offline_with_no_network(self, env, mocked_boards):
-        env.MBED_DATABASE_MODE = "AUTO"
+    def test_auto_mode_raises_when_board_not_found_offline_with_no_network(self, mock_env, mocked_boards):
+        mock_env.MBED_DATABASE_MODE = "AUTO"
         mocked_boards.from_offline_database().get_board.side_effect = UnknownBoard
         mocked_boards.from_online_database().get_board.side_effect = BoardAPIError
         fn = mock.Mock()
 
-        with self.assertRaises(UnknownBoard):
+        with pytest.raises(UnknownBoard):
             get_board(fn)
         mocked_boards.from_offline_database().get_board.assert_called_once_with(fn)
         mocked_boards.from_online_database().get_board.assert_called_once_with(fn)
 
 
-class TestGetBoardByProductCode(TestCase):
-    @mock.patch("mbed_tools.targets.get_board.get_board")
+class TestGetBoardByProductCode:
     def test_matches_boards_by_product_code(self, mock_get_board):
         product_code = "swag"
 
-        self.assertEqual(get_board_by_product_code(product_code), mock_get_board.return_value)
+        assert get_board_by_product_code(product_code) == mock_get_board.return_value
 
         # Test callable matches correct boards
         fn = mock_get_board.call_args[0][0]
@@ -86,16 +103,15 @@ class TestGetBoardByProductCode(TestCase):
         matching_board = make_board(product_code=product_code)
         not_matching_board = make_board(product_code="whatever")
 
-        self.assertTrue(fn(matching_board))
-        self.assertFalse(fn(not_matching_board))
+        assert fn(matching_board)
+        assert not fn(not_matching_board)
 
 
-class TestGetBoardByOnlineId(TestCase):
-    @mock.patch("mbed_tools.targets.get_board.get_board")
+class TestGetBoardByOnlineId:
     def test_matches_boards_by_online_id(self, mock_get_board):
         target_type = "platform"
 
-        self.assertEqual(get_board_by_online_id(slug="slug", target_type=target_type), mock_get_board.return_value)
+        assert get_board_by_online_id(slug="slug", target_type=target_type) == mock_get_board.return_value
 
         # Test callable matches correct boards
         fn = mock_get_board.call_args[0][0]
@@ -104,18 +120,17 @@ class TestGetBoardByOnlineId(TestCase):
         matching_board_2 = make_board(target_type=target_type, slug="SlUg")
         not_matching_board = make_board(target_type=target_type, slug="whatever")
 
-        self.assertTrue(fn(matching_board_1))
-        self.assertTrue(fn(matching_board_2))
-        self.assertFalse(fn(not_matching_board))
+        assert fn(matching_board_1)
+        assert fn(matching_board_2)
+        assert not fn(not_matching_board)
 
 
-@mock.patch("mbed_tools.targets.get_board.env", spec_set=env)
-class TestGetDatabaseMode(TestCase):
-    def test_returns_configured_database_mode(self, env):
-        env.MBED_DATABASE_MODE = "OFFLINE"
-        self.assertEqual(_get_database_mode(), _DatabaseMode.OFFLINE)
+class TestGetDatabaseMode:
+    def test_returns_configured_database_mode(self, mock_env):
+        mock_env.MBED_DATABASE_MODE = "OFFLINE"
+        assert _get_database_mode() == _DatabaseMode.OFFLINE
 
-    def test_raises_when_configuration_is_not_supported(self, env):
-        env.MBED_DATABASE_MODE = "NOT_VALID"
-        with self.assertRaises(UnsupportedMode):
+    def test_raises_when_configuration_is_not_supported(self, mock_env):
+        mock_env.MBED_DATABASE_MODE = "NOT_VALID"
+        with pytest.raises(UnsupportedMode):
             _get_database_mode()

--- a/tests/targets/test_get_board.py
+++ b/tests/targets/test_get_board.py
@@ -10,7 +10,7 @@ from unittest import mock
 from mbed_tools.targets._internal.exceptions import BoardAPIError
 
 # Import from top level as this is the expected interface for users
-from mbed_tools.targets import get_board_by_online_id, get_board_by_product_code
+from mbed_tools.targets import get_board_by_online_id, get_board_by_product_code, get_board_by_jlink_slug
 from mbed_tools.targets.get_board import (
     _DatabaseMode,
     _get_database_mode,
@@ -122,6 +122,24 @@ class TestGetBoardByOnlineId:
 
         assert fn(matching_board_1)
         assert fn(matching_board_2)
+        assert not fn(not_matching_board)
+
+
+class TestGetBoardByJlinkSlug:
+    def test_matches_boards_by_online_id(self, mock_get_board):
+        assert get_board_by_jlink_slug(slug="slug") == mock_get_board.return_value
+
+        # Test callable matches correct boards
+        fn = mock_get_board.call_args[0][0]
+
+        matching_board_1 = make_board(slug="slug")
+        matching_board_2 = make_board(board_type="slug")
+        matching_board_3 = make_board(board_name="slug")
+        not_matching_board = make_board()
+
+        assert fn(matching_board_1)
+        assert fn(matching_board_2)
+        assert fn(matching_board_3)
         assert not fn(not_matching_board)
 
 


### PR DESCRIPTION
### Description

When connecting with J-Link, some files we rely on for identifying the board may not be present. This adds parsers for `Segger.html` and `Board.html` files, and extracts the type of J-Link in use and the slug from the manufacturer's board URL. This slug will not always correspond to the Mbed slug, so an additional function is added to search for the matching board. This attempts to find a board in the database which matches any of `slug`, `board_name` or `board_type` with the extracted slug.


### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [x]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
