### PR TITLE
devices: Make parser more lenient to unknown layouts

### DIFF
--- a/news/258.bugfix
+++ b/news/258.bugfix
@@ -1,0 +1,1 @@
+Make details.txt parsing more lenient to avoid issues with various formats.

--- a/src/mbed_tools/devices/_internal/file_parser.py
+++ b/src/mbed_tools/devices/_internal/file_parser.py
@@ -214,8 +214,9 @@ def _read_details_txt(file_contents: str) -> dict:
         if line.startswith("#"):
             continue
 
-        key, value = line.split(":", maxsplit=1)
-        output[key.strip()] = value.strip()
+        key, sep, value = line.partition(":")
+        if key and value:
+            output[key.strip()] = value.strip()
 
     # Some forms of details.txt use Interface Version instead of Version as the key for the version number field
     if "Interface Version" in output and "Version" not in output:

--- a/tests/devices/_internal/test_file_parser.py
+++ b/tests/devices/_internal/test_file_parser.py
@@ -233,8 +233,11 @@ class TestReadDetailsTxt:
             build_short_details_txt(version="0777", commit_sha="99789s", local_mods="No"),
             build_long_details_txt(),
             ("", {}),
+            ("\n", {}),
+            ("blablablablaandbla", {}),
+            ("blablabla\nblaandbla\nversion : 2\n\n", {"version": "2"}),
         ),
-        ids=("short", "short2", "long", "empty"),
+        ids=("short", "short2", "long", "empty", "newline", "nosep", "multiline"),
     )
     def test_parses_details_txt(self, content, expected, tmp_path):
         details_file_path = pathlib.Path(tmp_path, "DETAILS.txt")


### PR DESCRIPTION
### Description

We can't guarantee details.txt will be in the form "key: value" with a
":" separator on every line. Sometimes they even end with a trailing
newline. Make the code more lenient by using str.partition instead of
str.split, which will return empty strings if the separator isn't found,
rather than raising an exception.

Fixes #258



<!--
Please add any detail or context that would be useful to a reviewer.
-->



### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [x]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
