### PR TITLE
CMake: Render CMakeLists template from mbed-os

### DIFF
--- a/news/273.bugfix
+++ b/news/273.bugfix
@@ -1,0 +1,1 @@
+Refactor the new command to fetch and render the CMakeLists template from mbed-os.

--- a/tests/project/_internal/test_render_templates.py
+++ b/tests/project/_internal/test_render_templates.py
@@ -15,10 +15,25 @@ from mbed_tools.project._internal.render_templates import (
 
 @mock.patch("mbed_tools.project._internal.render_templates.datetime")
 class TestRenderTemplates(TestCase):
-    def test_renders_cmakelists_template(self, mock_datetime):
+    def test_renders_cmakelists_template_from_cache(self, mock_datetime):
         with TemporaryDirectory() as tmpdir:
             the_year = 3999
             mock_datetime.datetime.now.return_value.year = the_year
+            program_name = "mytestprogram"
+            file_path = Path(tmpdir, "mytestpath")
+
+            render_cmakelists_template(file_path, program_name)
+
+            output = file_path.read_text()
+            self.assertIn(str(the_year), output)
+            self.assertIn(program_name, output)
+
+    @mock.patch("mbed_tools.project._internal.render_templates.requests")
+    def test_renders_cmakelists_template_from_mbed(self, mock_requests, mock_datetime):
+        with TemporaryDirectory() as tmpdir:
+            the_year = 3999
+            mock_datetime.datetime.now.return_value.year = the_year
+            mock_requests.get.return_value.text = "{{year}}     {{program_name}}"
             program_name = "mytestprogram"
             file_path = Path(tmpdir, "mytestpath")
 


### PR DESCRIPTION
### Description

`CMakeLists.tmpl` has been copied into `tools/cmake` in mbed-os. This is
the copy that should be used when creating a project from new i.e.
`mbed-tools new`. The cached copy of the template should only be used
if fetching the new template fails.

### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [x]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
