### PR TITLE
Refactor tests to use pytest fixtures and remove TestCase

### DIFF
--- a/news/20210512103446.misc
+++ b/news/20210512103446.misc
@@ -1,0 +1,1 @@
+Remove unittest.TestCase from tests and replace repetitive code with use of pytest fixtures.

--- a/tests/project/_internal/test_render_templates.py
+++ b/tests/project/_internal/test_render_templates.py
@@ -3,8 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 from pathlib import Path
-from tempfile import TemporaryDirectory
-from unittest import TestCase, mock
+from unittest import mock
 
 from mbed_tools.project._internal.render_templates import (
     render_cmakelists_template,
@@ -14,35 +13,32 @@ from mbed_tools.project._internal.render_templates import (
 
 
 @mock.patch("mbed_tools.project._internal.render_templates.datetime")
-class TestRenderTemplates(TestCase):
-    def test_renders_cmakelists_template(self, mock_datetime):
-        with TemporaryDirectory() as tmpdir:
-            the_year = 3999
-            mock_datetime.datetime.now.return_value.year = the_year
-            program_name = "mytestprogram"
-            file_path = Path(tmpdir, "mytestpath")
+class TestRenderTemplates:
+    def test_renders_cmakelists_template(self, mock_datetime, tmp_path):
+        the_year = 3999
+        mock_datetime.datetime.now.return_value.year = the_year
+        program_name = "mytestprogram"
+        file_path = Path(tmp_path, "mytestpath")
 
-            render_cmakelists_template(file_path, program_name)
+        render_cmakelists_template(file_path, program_name)
+        output = file_path.read_text()
 
-            output = file_path.read_text()
-            self.assertIn(str(the_year), output)
-            self.assertIn(program_name, output)
+        assert str(the_year) in output
+        assert program_name in output
 
-    def test_renders_main_cpp_template(self, mock_datetime):
-        with TemporaryDirectory() as tmpdir:
-            the_year = 3999
-            mock_datetime.datetime.now.return_value.year = the_year
-            file_path = Path(tmpdir, "mytestpath")
+    def test_renders_main_cpp_template(self, mock_datetime, tmp_path):
+        the_year = 3999
+        mock_datetime.datetime.now.return_value.year = the_year
+        file_path = Path(tmp_path, "mytestpath")
 
-            render_main_cpp_template(file_path)
+        render_main_cpp_template(file_path)
 
-            self.assertIn(str(the_year), file_path.read_text())
+        assert str(the_year) in file_path.read_text()
 
-    def test_renders_gitignore_template(self, _):
-        with TemporaryDirectory() as tmpdir:
-            file_path = Path(tmpdir, "mytestpath")
+    def test_renders_gitignore_template(self, _, tmp_path):
+        file_path = Path(tmp_path, "mytestpath")
 
-            render_gitignore_template(file_path)
+        render_gitignore_template(file_path)
 
-            self.assertIn("cmake_build", file_path.read_text())
-            self.assertIn(".mbedbuild", file_path.read_text())
+        assert "cmake_build" in file_path.read_text()
+        assert ".mbedbuild" in file_path.read_text()

--- a/tests/project/factories.py
+++ b/tests/project/factories.py
@@ -2,23 +2,12 @@
 # Copyright (c) 2020-2021 Arm Limited and Contributors. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
-from functools import wraps
-from tempfile import TemporaryDirectory
 from mbed_tools.project._internal.libraries import MbedLibReference
 from mbed_tools.project._internal.project_data import (
     CMAKELISTS_FILE_NAME,
     APP_CONFIG_FILE_NAME,
     MBED_OS_REFERENCE_FILE_NAME,
 )
-
-
-def patchfs(func):
-    @wraps(func)
-    def wrapper(*args, **kwargs):
-        with TemporaryDirectory() as fs:
-            func(*args, fs=fs, **kwargs)
-
-    return wrapper
 
 
 def make_mbed_program_files(root, config_file_name=APP_CONFIG_FILE_NAME):

--- a/tests/project/test_mbed_program.py
+++ b/tests/project/test_mbed_program.py
@@ -4,14 +4,14 @@
 #
 import os
 import pathlib
+import pytest
 
-from unittest import TestCase
 
 from mbed_tools.project import MbedProgram
 from mbed_tools.project.exceptions import ExistingProgram, ProgramNotFound, MbedOSNotFound
 from mbed_tools.project.mbed_program import _find_program_root, parse_url
 from mbed_tools.project._internal.project_data import MbedProgramFiles
-from tests.project.factories import make_mbed_program_files, make_mbed_os_files, patchfs
+from tests.project.factories import make_mbed_program_files, make_mbed_os_files
 
 
 DEFAULT_BUILD_SUBDIR = pathlib.Path("K64F", "develop", "GCC_ARM")
@@ -24,83 +24,75 @@ def from_new_set_target_toolchain(program_root):
     return program
 
 
-class TestInitialiseProgram(TestCase):
-    @patchfs
-    def test_from_new_local_dir_raises_if_path_is_existing_program(self, fs):
-        program_root = pathlib.Path(fs, "programfoo")
+class TestInitialiseProgram:
+    def test_from_new_local_dir_raises_if_path_is_existing_program(self, tmp_path):
+        program_root = pathlib.Path(tmp_path, "programfoo")
         program_root.mkdir()
         (program_root / "mbed-os.lib").touch()
 
-        with self.assertRaises(ExistingProgram):
+        with pytest.raises(ExistingProgram):
             MbedProgram.from_new(program_root)
 
-    @patchfs
-    def test_from_new_local_dir_generates_valid_program_creating_directory(self, fs):
-        fs_root = pathlib.Path(fs, "foo")
+    def test_from_new_local_dir_generates_valid_program_creating_directory(self, tmp_path):
+        fs_root = pathlib.Path(tmp_path, "foo")
         fs_root.mkdir()
         program_root = fs_root / "programfoo"
 
         program = from_new_set_target_toolchain(program_root)
 
-        self.assertEqual(program.files, MbedProgramFiles.from_existing(program_root, DEFAULT_BUILD_SUBDIR))
+        assert program.files == MbedProgramFiles.from_existing(program_root, DEFAULT_BUILD_SUBDIR)
 
-    @patchfs
-    def test_from_new_local_dir_generates_valid_program_creating_directory_in_cwd(self, fs):
+    def test_from_new_local_dir_generates_valid_program_creating_directory_in_cwd(self, tmp_path):
         old_cwd = os.getcwd()
         try:
-            fs_root = pathlib.Path(fs, "foo")
+            fs_root = pathlib.Path(tmp_path, "foo")
             fs_root.mkdir()
             os.chdir(fs_root)
             program_root = pathlib.Path("programfoo")
 
             program = from_new_set_target_toolchain(program_root)
 
-            self.assertEqual(program.files, MbedProgramFiles.from_existing(program_root, DEFAULT_BUILD_SUBDIR))
+            assert program.files == MbedProgramFiles.from_existing(program_root, DEFAULT_BUILD_SUBDIR)
         finally:
             os.chdir(old_cwd)
 
-    @patchfs
-    def test_from_new_local_dir_generates_valid_program_existing_directory(self, fs):
-        fs_root = pathlib.Path(fs, "foo")
+    def test_from_new_local_dir_generates_valid_program_existing_directory(self, tmp_path):
+        fs_root = pathlib.Path(tmp_path, "foo")
         fs_root.mkdir()
         program_root = fs_root / "programfoo"
         program_root.mkdir()
 
         program = from_new_set_target_toolchain(program_root)
 
-        self.assertEqual(program.files, MbedProgramFiles.from_existing(program_root, DEFAULT_BUILD_SUBDIR))
+        assert program.files == MbedProgramFiles.from_existing(program_root, DEFAULT_BUILD_SUBDIR)
 
-    @patchfs
-    def test_from_existing_raises_if_path_is_not_a_program(self, fs):
-        fs_root = pathlib.Path(fs, "foo")
+    def test_from_existing_raises_if_path_is_not_a_program(self, tmp_path):
+        fs_root = pathlib.Path(tmp_path, "foo")
         fs_root.mkdir()
         program_root = fs_root / "programfoo"
 
-        with self.assertRaises(ProgramNotFound):
+        with pytest.raises(ProgramNotFound):
             MbedProgram.from_existing(program_root, DEFAULT_BUILD_SUBDIR)
 
-    @patchfs
-    def test_from_existing_raises_if_no_mbed_os_dir_found_and_check_mbed_os_is_true(self, fs):
-        fs_root = pathlib.Path(fs, "foo")
+    def test_from_existing_raises_if_no_mbed_os_dir_found_and_check_mbed_os_is_true(self, tmp_path):
+        fs_root = pathlib.Path(tmp_path, "foo")
         make_mbed_program_files(fs_root)
 
-        with self.assertRaises(MbedOSNotFound):
+        with pytest.raises(MbedOSNotFound):
             MbedProgram.from_existing(fs_root, DEFAULT_BUILD_SUBDIR, check_mbed_os=True)
 
-    @patchfs
-    def test_from_existing_returns_valid_program(self, fs):
-        fs_root = pathlib.Path(fs, "foo")
+    def test_from_existing_returns_valid_program(self, tmp_path):
+        fs_root = pathlib.Path(tmp_path, "foo")
         make_mbed_program_files(fs_root)
         make_mbed_os_files(fs_root / "mbed-os")
 
         program = MbedProgram.from_existing(fs_root, DEFAULT_BUILD_SUBDIR)
 
-        self.assertTrue(program.files.app_config_file.exists())
-        self.assertTrue(program.mbed_os.root.exists())
+        assert program.files.app_config_file.exists()
+        assert program.mbed_os.root.exists()
 
-    @patchfs
-    def test_from_existing_with_mbed_os_path_returns_valid_program(self, fs):
-        fs_root = pathlib.Path(fs, "foo")
+    def test_from_existing_with_mbed_os_path_returns_valid_program(self, tmp_path):
+        fs_root = pathlib.Path(tmp_path, "foo")
         mbed_os_path = fs_root / "extern/mbed-os"
         mbed_os_path.mkdir(parents=True)
         make_mbed_program_files(fs_root)
@@ -108,53 +100,50 @@ class TestInitialiseProgram(TestCase):
 
         program = MbedProgram.from_existing(fs_root, DEFAULT_BUILD_SUBDIR, mbed_os_path)
 
-        self.assertTrue(program.files.app_config_file.exists())
-        self.assertTrue(program.mbed_os.root.exists())
+        assert program.files.app_config_file.exists()
+        assert program.mbed_os.root.exists()
 
 
-class TestParseURL(TestCase):
+class TestParseURL:
     def test_creates_url_and_dst_dir_from_name(self):
         name = "mbed-os-example-blows-up-board"
         data = parse_url(name)
 
-        self.assertEqual(data["url"], f"https://github.com/armmbed/{name}")
-        self.assertEqual(data["dst_path"], name)
+        assert data["url"] == f"https://github.com/armmbed/{name}"
+        assert data["dst_path"] == name
 
     def test_creates_valid_dst_dir_from_url(self):
         url = "https://superversioncontrol/superorg/mbed-os-example-numskull"
         data = parse_url(url)
 
-        self.assertEqual(data["url"], url)
-        self.assertEqual(data["dst_path"], "mbed-os-example-numskull")
+        assert data["url"] == url
+        assert data["dst_path"] == "mbed-os-example-numskull"
 
     def test_creates_valid_dst_dir_from_ssh_url(self):
         url = "git@superversioncontrol:superorg/mbed-os-example-numskull"
         data = parse_url(url)
-        self.assertEqual(data["url"], url)
-        self.assertEqual(data["dst_path"], "mbed-os-example-numskull")
+        assert data["url"] == url
+        assert data["dst_path"] == "mbed-os-example-numskull"
 
 
-class TestFindProgramRoot(TestCase):
-    @patchfs
-    def test_finds_program_higher_in_dir_tree(self, fs):
-        program_root = pathlib.Path(fs, "foo")
+class TestFindProgramRoot:
+    def test_finds_program_higher_in_dir_tree(self, tmp_path):
+        program_root = pathlib.Path(tmp_path, "foo")
         pwd = program_root / "subprojfoo" / "libbar"
         make_mbed_program_files(program_root)
         pwd.mkdir(parents=True)
 
-        self.assertEqual(_find_program_root(pwd), program_root.resolve())
+        assert _find_program_root(pwd) == program_root.resolve()
 
-    @patchfs
-    def test_finds_program_at_current_path(self, fs):
-        program_root = pathlib.Path(fs, "foo")
+    def test_finds_program_at_current_path(self, tmp_path):
+        program_root = pathlib.Path(tmp_path, "foo")
         make_mbed_program_files(program_root)
 
-        self.assertEqual(_find_program_root(program_root), program_root.resolve())
+        assert _find_program_root(program_root) == program_root.resolve()
 
-    @patchfs
-    def test_raises_if_no_program_found(self, fs):
-        program_root = pathlib.Path(fs, "foo")
+    def test_raises_if_no_program_found(self, tmp_path):
+        program_root = pathlib.Path(tmp_path, "foo")
         program_root.mkdir()
 
-        with self.assertRaises(ProgramNotFound):
+        with pytest.raises(ProgramNotFound):
             _find_program_root(program_root)


### PR DESCRIPTION
### Description

In `test_mbed_program`, `test_project_data` and `test_render_templates`, temporary directories are created either with use of a decorator from `factories.py` or with repetitive code in each test case.

Use of `unittest.TestCase` is removed from these files, and the pytest `tmp_path` fixture is used to provide temporary directories.

### Test Coverage

- [x]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
