### PR TITLE
 Fix issue with memory region overrides

### DIFF
--- a/news/20210524113403.bugfix
+++ b/news/20210524113403.bugfix
@@ -1,0 +1,1 @@
+Fix issue with memory region overrides being ignored.

--- a/src/mbed_tools/build/_internal/cmake_file.py
+++ b/src/mbed_tools/build/_internal/cmake_file.py
@@ -5,6 +5,8 @@
 """Module in charge of CMake file generation."""
 import pathlib
 
+from typing import Any
+
 import jinja2
 
 from mbed_tools.build._internal.config.config import Config
@@ -25,7 +27,13 @@ def render_mbed_config_cmake_template(config: Config, toolchain_name: str, targe
         The rendered mbed_config template.
     """
     env = jinja2.Environment(loader=jinja2.PackageLoader("mbed_tools.build", str(TEMPLATES_DIRECTORY)),)
+    env.filters["to_hex"] = to_hex
     template = env.get_template(TEMPLATE_NAME)
     config["supported_c_libs"] = [x for x in config["supported_c_libs"][toolchain_name.lower()]]
     context = {"target_name": target_name, "toolchain_name": toolchain_name, **config}
     return template.render(context)
+
+
+def to_hex(s: Any) -> str:
+    """Filter to convert integers to hex."""
+    return hex(int(s, 0))

--- a/src/mbed_tools/build/_internal/config/config.py
+++ b/src/mbed_tools/build/_internal/config/config.py
@@ -8,7 +8,7 @@ import logging
 from collections import UserDict
 from typing import Any, Iterable, Hashable, Callable, List
 
-from mbed_tools.build._internal.config.source import Memory, Override, ConfigSetting
+from mbed_tools.build._internal.config.source import Override, ConfigSetting
 
 logger = logging.getLogger(__name__)
 
@@ -18,15 +18,13 @@ class Config(UserDict):
 
     This object understands how to populate the different 'config sections' which all have different rules for how the
     settings are collected.
-    Applies overrides, appends macros, updates memories, and updates config settings.
+    Applies overrides, appends macros, and updates config settings.
     """
 
     def __setitem__(self, key: Hashable, item: Any) -> None:
         """Set an item based on its key."""
         if key == CONFIG_SECTION:
             self._update_config_section(item)
-        elif key == MEMORIES_SECTION:
-            self._update_memories_section(item)
         elif key == OVERRIDES_SECTION:
             self._handle_overrides(item)
         elif key == MACROS_SECTION:
@@ -69,20 +67,6 @@ class Config(UserDict):
 
         self.data[CONFIG_SECTION] = self.data.get(CONFIG_SECTION, []) + config_settings
 
-    def _update_memories_section(self, memories: List[Memory]) -> None:
-        defined_memories = self.data.get(MEMORIES_SECTION, [])
-        for memory in memories:
-            logger.debug(f"Adding memory settings `{memory.name}: start={memory.start} size={memory.size}`")
-            prev_defined = next((mem for mem in defined_memories if mem.name == memory.name), None)
-            if prev_defined is None:
-                defined_memories.append(memory)
-            else:
-                logger.warning(
-                    f"You are attempting to redefine `{memory.name}` from {prev_defined.namespace}.\n"
-                    f"The values from `{memory.namespace}` will be ignored"
-                )
-        self.data[MEMORIES_SECTION] = defined_memories
-
     def _find_first_config_setting(self, predicate: Callable) -> Any:
         """Find first config setting based on `predicate`.
 
@@ -105,7 +89,6 @@ class Config(UserDict):
 
 CONFIG_SECTION = "config"
 MACROS_SECTION = "macros"
-MEMORIES_SECTION = "memories"
 OVERRIDES_SECTION = "overrides"
 
 

--- a/src/mbed_tools/build/_internal/templates/mbed_config.tmpl
+++ b/src/mbed_tools/build/_internal/templates/mbed_config.tmpl
@@ -75,10 +75,6 @@ set(MBED_CONFIG_DEFINITIONS
     "-D{{setting_name}}={{value}}"
     {% endif -%}
 {%- endfor -%}
-{% for memory in memories %}
-    "-DMBED_{{memory.name}}_START={{memory.start}}"
-    "-DMBED_{{memory.name}}_SIZE={{memory.size}}"
-{%- endfor -%}
 {% for macro in macros %}
     "{{macro|replace("\"", "\\\"")}}"
 {%- endfor %}

--- a/src/mbed_tools/build/_internal/templates/mbed_config.tmpl
+++ b/src/mbed_tools/build/_internal/templates/mbed_config.tmpl
@@ -54,6 +54,18 @@ set(MBED_TARGET_DEFINITIONS{% for component in components %}
 {% for form_factor in supported_form_factors %}
     TARGET_FF_{{form_factor}}
 {%- endfor %}
+{% if mbed_rom_start is defined %}
+    MBED_ROM_START={{ mbed_rom_start | to_hex }}
+{%- endif %}
+{% if mbed_rom_size is defined %}
+    MBED_ROM_SIZE={{ mbed_rom_size | to_hex }}
+{%- endif %}
+{% if mbed_ram_start is defined %}
+    MBED_RAM_START={{ mbed_ram_start | to_hex }}
+{%- endif %}
+{% if mbed_ram_size is defined %}
+    MBED_RAM_SIZE={{ mbed_ram_size | to_hex }}
+{%- endif %}
     TARGET_LIKE_MBED
     __MBED__=1
 )

--- a/tests/build/_internal/config/test_config.py
+++ b/tests/build/_internal/config/test_config.py
@@ -2,11 +2,10 @@
 # Copyright (c) 2020-2021 Arm Limited and Contributors. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
-import logging
 import pytest
 
 from mbed_tools.build._internal.config.config import Config
-from mbed_tools.build._internal.config.source import prepare, ConfigSetting, Memory, Override
+from mbed_tools.build._internal.config.source import prepare, ConfigSetting, Override
 
 
 class TestConfig:
@@ -24,17 +23,6 @@ class TestConfig:
 
         with pytest.raises(ValueError, match="lib.param already defined"):
             conf.update(prepare({"config": {"param": {"value": 0}}}, source_name="lib"))
-
-    def test_logs_ignore_mbed_ram_repeated(self, caplog):
-        caplog.set_level(logging.DEBUG)
-        input_dict = {"mbed_ram_size": "0x80000", "mbed_ram_start": "0x24000000"}
-        input_dict2 = {"mbed_ram_size": "0x78000", "mbed_ram_start": "0x24200000"}
-
-        conf = Config(prepare(input_dict, source_name="lib1"))
-        conf.update(prepare(input_dict2, source_name="lib2"))
-
-        assert "values from `lib2` will be ignored" in caplog.text
-        assert conf["memories"] == [Memory("RAM", "lib1", "0x24000000", "0x80000")]
 
     def test_target_overrides_handled(self):
         conf = Config(

--- a/tests/build/_internal/config/test_source.py
+++ b/tests/build/_internal/config/test_source.py
@@ -2,10 +2,8 @@
 # Copyright (c) 2020-2021 Arm Limited and Contributors. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
-import pytest
-
 from mbed_tools.build._internal.config import source
-from mbed_tools.build._internal.config.source import Memory, Override
+from mbed_tools.build._internal.config.source import Override
 
 
 class TestPrepareSource:
@@ -120,48 +118,3 @@ class TestPrepareSource:
         assert conf["config"][0].value == {"ETHERNET", "WIFI"}
         assert conf["sectors"] == {0, 2048}
         assert conf["header_info"] == {0, 2048, "bobbins", "magic"}
-
-    def test_memory_attr_extracted(self):
-        lib = {
-            "mbed_ram_size": "0x80000",
-            "mbed_ram_start": "0x24000000",
-            "mbed_rom_size": "0x200000",
-            "mbed_rom_start": "0x08000000",
-        }
-
-        conf = source.prepare(lib, "lib")
-
-        assert Memory("RAM", "lib", "0x24000000", "0x80000") in conf["memories"]
-        assert Memory("ROM", "lib", "0x8000000", "0x200000") in conf["memories"]
-
-    def test_memory_attr_converted_as_hex(self):
-        input_dict = {"mbed_ram_size": "1024", "mbed_ram_start": "0x24000000"}
-
-        conf = source.prepare(input_dict, source_name="lib")
-
-        memory, *_ = conf["memories"]
-        assert memory.size == "0x400"
-
-    def test_raises_memory_size_not_integer(self):
-        input_dict = {"mbed_ram_size": "NOT INT", "mbed_ram_start": "0x24000000"}
-
-        with pytest.raises(ValueError, match="_SIZE in lib, NOT INT is invalid: must be an integer"):
-            source.prepare(input_dict, "lib")
-
-    def test_raises_memory_start_not_integer(self):
-        input_dict = {"mbed_ram_size": "0x80000", "mbed_ram_start": "NOT INT"}
-
-        with pytest.raises(ValueError, match="_START in lib, NOT INT is invalid: must be an integer"):
-            source.prepare(input_dict, "lib")
-
-    def test_raises_memory_size_defined_not_start(self):
-        input_dict = {"mbed_ram_size": "0x80000"}
-
-        with pytest.raises(ValueError, match="Only SIZE is defined"):
-            source.prepare(input_dict)
-
-    def test_raises_memory_start_defined_not_size(self):
-        input_dict = {"mbed_ram_start": "0x24000000"}
-
-        with pytest.raises(ValueError, match="Only START is defined"):
-            source.prepare(input_dict)

--- a/tests/build/test_generate_config.py
+++ b/tests/build/test_generate_config.py
@@ -48,6 +48,10 @@ TARGET_DATA = {
     "supported_toolchains": ["ARM", "GCC_ARM", "IAR"],
     "trustzone": False,
     "OUTPUT_EXT": "hex",
+    "mbed_ram_start": "0",
+    "mbed_ram_size": "0",
+    "mbed_rom_start": "0",
+    "mbed_rom_size": "0",
 }
 
 
@@ -289,6 +293,10 @@ def test_overrides_target_config_param_from_app(matching_target_and_filter, prog
         ("target.macros", ["DEFINE"], "DEFINE"),
         ("target.device_has", ["NOTHING"], "DEVICE_NOTHING"),
         ("target.features", ["ELECTRICITY"], "FEATURE_ELECTRICITY"),
+        ("target.mbed_rom_start", "99", "MBED_ROM_START=0x63"),
+        ("target.mbed_rom_size", "1010", "MBED_ROM_SIZE=0x3f2"),
+        ("target.mbed_ram_start", "99", "MBED_RAM_START=0x63"),
+        ("target.mbed_ram_size", "1010", "MBED_RAM_SIZE=0x3f2"),
         ("OUTPUT_EXT", "hex", 'MBED_OUTPUT_EXT "hex"'),
     ],
 )


### PR DESCRIPTION
### Description
MBED_ROM/RAM_START/SIZE overrides were not added to
mbed_config.cmake.

The reason mbed_app.json overrides were "ignored" is
because the overrides were applied to the already collected string
parameters and weren't applied to the extracted `Memory` objects we
expose in the template.

We shouldn't need special handling for mbed_rom/ram_start or
mbed_rom/ram_size as they are already collected (if present in
targets.json). So remove the special handling for memory regions.
A side effect of this approach is that we remove some of the validation
checks for START and SIZE both being defined. If we feel this is a 
necessary check we can add it back into the `Config` object.

Fixes #283

### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [x]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
