### PR TITLE
config: Ensure duplicate config file paths are discarded

### DIFF
--- a/news/20210524175020.bugfix
+++ b/news/20210524175020.bugfix
@@ -1,0 +1,1 @@
+Avoid searching config file paths twice when mbed-os-path is used and it is a subdirectory of the project path.

--- a/src/mbed_tools/build/_internal/config/assemble_build_config.py
+++ b/src/mbed_tools/build/_internal/config/assemble_build_config.py
@@ -33,7 +33,11 @@ def assemble_config(target_attributes: dict, search_paths: Iterable[Path], mbed_
         mbed_app_file: The path to mbed_app.json. This can be None.
     """
     mbed_lib_files = list(
-        set(itertools.chain.from_iterable(find_files("mbed_lib.json", path) for path in search_paths))
+        set(
+            itertools.chain.from_iterable(
+                find_files("mbed_lib.json", path.absolute().resolve()) for path in search_paths
+            )
+        )
     )
     return _assemble_config_from_sources(target_attributes, mbed_lib_files, mbed_app_file)
 

--- a/src/mbed_tools/build/_internal/find_files.py
+++ b/src/mbed_tools/build/_internal/find_files.py
@@ -52,6 +52,9 @@ def _find_files(filename: str, directory: Path, filters: Optional[List[Callable]
     filtered_children = filter_files(children, filters)
 
     for child in filtered_children:
+        if child.is_symlink():
+            child = child.absolute().resolve()
+
         if child.is_dir():
             # If processed child is a directory, recurse with current set of filters
             result += _find_files(filename, child, filters)

--- a/tests/build/_internal/config/test_assemble_build_config.py
+++ b/tests/build/_internal/config/test_assemble_build_config.py
@@ -6,7 +6,7 @@ import json
 from pathlib import Path
 from tempfile import TemporaryDirectory
 
-from mbed_tools.build._internal.config.assemble_build_config import _assemble_config_from_sources
+from mbed_tools.build._internal.config.assemble_build_config import _assemble_config_from_sources, assemble_config
 from mbed_tools.build._internal.config.config import Config
 from mbed_tools.build._internal.find_files import find_files
 from mbed_tools.build._internal.config.source import prepare
@@ -157,3 +157,47 @@ class TestAssembleConfigFromSourcesAndLibFiles:
             assert config["extra_labels"] == {"EXTRA_HOT"}
             assert config["labels"] == {"A", "PICKLE"}
             assert config["macros"] == {"TICKER", "RED_MACRO"}
+
+    def test_ignores_duplicate_paths_to_lib_files(self, tmp_path, monkeypatch):
+        target = {
+            "labels": {"A"},
+        }
+        mbed_lib_files = [
+            {
+                "path": Path("mbed-os", "TARGET_A", "mbed_lib.json"),
+                "json_contents": {"name": "a", "config": {"a": {"value": 4}}},
+            },
+        ]
+        _ = create_files(tmp_path, mbed_lib_files)
+        monkeypatch.chdir(tmp_path)
+
+        config = assemble_config(target, [tmp_path, Path("mbed-os")], None)
+
+        assert config["config"][0].name == "a"
+        assert config["config"][0].value == 4
+
+    def test_does_not_search_symlinks_in_proj_dir_twice(self, tmp_path, monkeypatch):
+        target = {
+            "labels": {"A"},
+        }
+        mbed_lib_files = [
+            {
+                "path": Path("mbed-os", "TARGET_A", "mbed_lib.json"),
+                "json_contents": {"name": "a", "config": {"a": {"value": 4}}},
+            },
+        ]
+        project_dir = tmp_path / "project"
+        project_dir.mkdir()
+
+        mbed_os_dir = tmp_path / "other" / "mbed-os"
+        mbed_os_dir.mkdir(parents=True)
+        _ = create_files(mbed_os_dir, mbed_lib_files)
+
+        monkeypatch.chdir(project_dir)
+        mbed_symlink = Path("mbed-os")
+        mbed_symlink.symlink_to(mbed_os_dir, target_is_directory=True)
+
+        config = assemble_config(target, [project_dir, mbed_symlink], None)
+
+        assert config["config"][0].name == "a"
+        assert config["config"][0].value == 4


### PR DESCRIPTION
### Description

When `mbed-os-path` was given on the command line, and it happened to be
a subdirectory of the project path it would be searched twice for
mbed_lib.json files. This would cause duplicate config parameter
exceptions to be raised.

Ensure duplicated config file paths are discarded by resolving the
absolute paths. This is so `Path.__eq__` can detect duplicate entries and
they are filtered when building the final set. Also ensure we handle the
case where a subdirectory of the search path is a symlink.

Fixes #234



<!--
Please add any detail or context that would be useful to a reviewer.
-->



### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [x]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
