### PR TITLE
build: Automatically determine image format to flash

### DIFF
--- a/news/20210602164800.feature
+++ b/news/20210602164800.feature
@@ -1,0 +1,1 @@
+The `--flash` option of `mbed-tools compile` now automatically selects bin or hex image. The option `--hex-file` is removed.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,4 +65,6 @@ name = "Misc"
 showcontent = false
 
 [tool.black]
+diff = true
+color = true
 line-length = 120

--- a/src/mbed_tools/build/config.py
+++ b/src/mbed_tools/build/config.py
@@ -5,20 +5,20 @@
 """Parses the Mbed configuration system and generates a CMake config script."""
 import pathlib
 
-from typing import Any
+from typing import Any, Tuple
 
 from mbed_tools.lib.json_helpers import decode_json_file
 from mbed_tools.project import MbedProgram
 from mbed_tools.targets import get_target_by_name
 from mbed_tools.build._internal.cmake_file import render_mbed_config_cmake_template
-from mbed_tools.build._internal.config.assemble_build_config import assemble_config
+from mbed_tools.build._internal.config.assemble_build_config import Config, assemble_config
 from mbed_tools.build._internal.write_files import write_file
 from mbed_tools.build.exceptions import MbedBuildError
 
 CMAKE_CONFIG_FILE = "mbed_config.cmake"
 
 
-def generate_config(target_name: str, toolchain: str, program: MbedProgram) -> pathlib.Path:
+def generate_config(target_name: str, toolchain: str, program: MbedProgram) -> Tuple[Config, pathlib.Path]:
     """Generate an Mbed config file at the program root by parsing the mbed config system.
 
     Args:
@@ -27,6 +27,7 @@ def generate_config(target_name: str, toolchain: str, program: MbedProgram) -> p
         program: The MbedProgram to configure.
 
     Returns:
+        Config object (UserDict)
         Path to the generated config file.
     """
     targets_data = _load_raw_targets_data(program)
@@ -39,7 +40,7 @@ def generate_config(target_name: str, toolchain: str, program: MbedProgram) -> p
     )
     cmake_config_file_path = program.files.cmake_build_dir / CMAKE_CONFIG_FILE
     write_file(cmake_config_file_path, cmake_file_contents)
-    return cmake_config_file_path
+    return config, cmake_config_file_path
 
 
 def _load_raw_targets_data(program: MbedProgram) -> Any:

--- a/src/mbed_tools/cli/build.py
+++ b/src/mbed_tools/cli/build.py
@@ -43,9 +43,6 @@ from mbed_tools.sterm import terminal
     "-f", "--flash", is_flag=True, default=False, help="Flash the binary onto a device",
 )
 @click.option(
-    "--hex-file", is_flag=True, default=False, help="Use hex file, this option should be used with '-f/--flash' option",
-)
-@click.option(
     "-s", "--sterm", is_flag=True, default=False, help="Launch a serial terminal to the device.",
 )
 @click.option(
@@ -61,7 +58,6 @@ def build(
     mbed_target: str = "",
     clean: bool = False,
     flash: bool = False,
-    hex_file: bool = False,
     sterm: bool = False,
     baudrate: int = 9600,
     mbed_os_path: str = None,
@@ -81,7 +77,6 @@ def build(
        mbed_target: The name of the Mbed target to build for.
        clean: Perform a clean build.
        flash: Flash the binary onto a device.
-       hex_file: Use hex file, this option should be used with '-f/--flash' option.
        sterm: Open a serial terminal to the connected target.
        baudrate: Change the serial baud rate (ignored unless --sterm is also given).
     """
@@ -100,7 +95,7 @@ def build(
     click.echo("Configuring project and generating build system...")
     if custom_targets_json is not None:
         program.files.custom_targets_json = pathlib.Path(custom_targets_json)
-    generate_config(mbed_target.upper(), toolchain, program)
+    config, _ = generate_config(mbed_target.upper(), toolchain, program)
     generate_build_system(program.root, build_tree, profile)
 
     click.echo("Building Mbed project...")
@@ -114,10 +109,9 @@ def build(
 
     if flash:
         for dev in devices:
+            hex_file = "OUTPUT_EXT" in config and config["OUTPUT_EXT"] == "hex"
             flashed_path = flash_binary(dev.mount_points[0].resolve(), program.root, build_tree, mbed_target, hex_file)
         click.echo(f"Copied {str(flashed_path.resolve())} to {len(devices)} device(s).")
-    elif hex_file:
-        click.echo("'--hex-file' option should be used with '-f/--flash' option")
 
     if sterm:
         dev = devices[0]

--- a/src/mbed_tools/cli/configure.py
+++ b/src/mbed_tools/cli/configure.py
@@ -67,5 +67,5 @@ def configure(
         program.files.cmake_build_dir = pathlib.Path(output_dir)
 
     mbed_target = mbed_target.upper()
-    output_path = generate_config(mbed_target, toolchain, program)
+    _, output_path = generate_config(mbed_target, toolchain, program)
     click.echo(f"mbed_config.cmake has been generated and written to '{str(output_path.resolve())}'")


### PR DESCRIPTION
### Description

<!--
Please add any detail or context that would be useful to a reviewer.
-->

The default image format is bin, but targets can override it with `"OUTPUT_EXT": "hex"` in `targets.json`. This is already taken care of in the CMake configuration generated by mbed-tools, but user still need to pass `--hex-image` if they want to run `mbed-tools compile` with `--flash` to flash a hex image.

This commit makes the image selection automatic based on `OUTPUT_EXT`.

Note: `--hex-file` is now redundant and thus removed. It does not make sense to have it anymore without also offering `--bin-file` for completeness.
    
The test cases for bin and hex image flashing have been updated accordingly. Coverage for `OUTPUT_EXT` has been improved, with both `mbed_config.cmake` and image format to flash checked.

### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [x]  This change is covered by existing or additional automated tests.
- [x]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).

The test case for hex image flashing has been updated accordingly.
Also manually tested on NRF52_DK (hex image) and DISCO_L475VG_IOT01A (bin image).