### PR TITLE
configure: Add --profile for profile selection

### DIFF
--- a/news/262.bugfix
+++ b/news/262.bugfix
@@ -1,0 +1,1 @@
+Add `-b`, `--profile` to the `configure` subcommand for specifying build profile.

--- a/src/mbed_tools/cli/configure.py
+++ b/src/mbed_tools/cli/configure.py
@@ -25,6 +25,7 @@ from mbed_tools.build import generate_config
     help="The toolchain you are using to build your app.",
 )
 @click.option("-m", "--mbed-target", required=True, help="A build target for an Mbed-enabled device, eg. K64F")
+@click.option("-b", "--profile", default="develop", help="The build type (release, develop or debug).")
 @click.option("-o", "--output-dir", type=click.Path(), default=None, help="Path to output directory.")
 @click.option(
     "-p",
@@ -42,6 +43,7 @@ from mbed_tools.build import generate_config
 def configure(
     toolchain: str,
     mbed_target: str,
+    profile: str,
     program_path: str,
     mbed_os_path: str,
     output_dir: str,
@@ -61,12 +63,13 @@ def configure(
         custom_targets_json: the path to custom_targets.json
         toolchain: the toolchain you are using (eg. GCC_ARM, ARM)
         mbed_target: the target you are building for (eg. K64F)
+        profile: The Mbed build profile (debug, develop or release).
         program_path: the path to the local Mbed program
         mbed_os_path: the path to the local Mbed OS directory
         output_dir: the path to the output directory
         app_config: the path to the application configuration file
     """
-    cmake_build_subdir = pathlib.Path(mbed_target.upper(), "develop", toolchain.upper())
+    cmake_build_subdir = pathlib.Path(mbed_target.upper(), profile.lower(), toolchain.upper())
     if mbed_os_path is None:
         program = MbedProgram.from_existing(pathlib.Path(program_path), cmake_build_subdir)
     else:

--- a/tests/cli/test_build.py
+++ b/tests/cli/test_build.py
@@ -186,6 +186,29 @@ class TestBuildCommand(TestCase):
             generate_config.assert_called_once_with(target.upper(), toolchain.upper(), program)
             self.assertEqual(program.files.app_config_file, app_config_path)
 
+    def test_profile_used_when_passed(
+        self, generate_config, mbed_program, build_project, generate_build_system
+    ):
+        program = mbed_program.from_existing()
+        mbed_program.reset_mock()  # clear call count from previous line
+
+        with mock_project_directory(program, mbed_config_exists=True, build_tree_exists=True):
+            generate_config.return_value = [mock.MagicMock(), mock.MagicMock()]
+
+            toolchain = "gcc_arm"
+            target = "k64f"
+            profile = "release"
+
+            runner = CliRunner()
+            runner.invoke(build, ["-t", toolchain, "-m", target, "--profile", profile])
+
+            mbed_program.from_existing.assert_called_once_with(
+                pathlib.Path(os.getcwd()),
+                pathlib.Path(target.upper(), profile, toolchain.upper())
+            )
+            generate_config.assert_called_once_with(target.upper(), toolchain.upper(), program)
+            generate_build_system.assert_called_once_with(program.root, program.files.cmake_build_dir, profile)
+
     def test_build_folder_removed_when_clean_flag_passed(
         self, generate_config, mbed_program, build_project, generate_build_system
     ):

--- a/tests/cli/test_configure.py
+++ b/tests/cli/test_configure.py
@@ -59,3 +59,23 @@ class TestConfigureCommand(TestCase):
 
         generate_config.assert_called_once_with("K64F", "GCC_ARM", program)
         self.assertEqual(program.files.app_config_file, app_config_path)
+
+    @mock.patch("mbed_tools.cli.configure.generate_config")
+    @mock.patch("mbed_tools.cli.configure.MbedProgram")
+    def test_profile_used_when_passed(self, program, generate_config):
+        test_program = program.from_existing()
+        program.reset_mock()  # clear call count from previous line
+
+        toolchain = "gcc_arm"
+        target = "k64f"
+        profile = "release"
+
+        CliRunner().invoke(
+            configure, ["-t", toolchain, "-m", target, "--profile", profile]
+        )
+
+        program.from_existing.assert_called_once_with(
+            pathlib.Path("."),
+            pathlib.Path(target.upper(), profile, toolchain.upper())
+        )
+        generate_config.assert_called_once_with("K64F", "GCC_ARM", test_program)


### PR DESCRIPTION
### Description

<!--
Please add any detail or context that would be useful to a reviewer.
-->

As `mbed-tools compile` supports `-b`, `--profile` for selecting a build profile, the same should exist for `mbed-tools configure` as users may want to manually run the build step using `cmake` in some cases. This PR implements it and supplies a test.

Note: This only affects the build directory - it has no impact on the contents of `mbed_config.cmake`. To actually build an application with a profile, a user needs to either run `mbed-tools compile` with `--profile <profile>`, or manually run `cmake` with `-DCMAKE_BUILD_TYPE=<profile>` after `mbed-tools configure`.

Also add missing test for `--profile` of `mbed-tools compile`.

Fixes #262

### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [x]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
