### PR TITLE
config: Do not prepend definitions with `-D`

### DIFF
--- a/news/20210708144331.misc
+++ b/news/20210708144331.misc
@@ -1,0 +1,1 @@
+Generate mbed_config.cmake without `-D` prepended to each macro in `MBED_CONFIG_DEFINITIONS`

--- a/src/mbed_tools/build/_internal/templates/mbed_config.tmpl
+++ b/src/mbed_tools/build/_internal/templates/mbed_config.tmpl
@@ -84,7 +84,7 @@ set(MBED_CONFIG_DEFINITIONS
         {% set value = setting.value|replace("\"", "\\\"") -%}
     {%- endif -%}
     {%- if setting.value is not none -%}
-    "-D{{setting_name}}={{value}}"
+    "{{setting_name}}={{value}}"
     {% endif -%}
 {%- endfor -%}
 {% for macro in macros %}

--- a/tests/build/_internal/test_cmake_file.py
+++ b/tests/build/_internal/test_cmake_file.py
@@ -60,4 +60,4 @@ class TestRendersCMakeListsFile:
         ]
 
         result = render_mbed_config_cmake_template(config, TOOLCHAIN_NAME, "target_name")
-        assert '"-DMBED_CONF_IOTC_MQTT_HOST={\\"mqtt.2030.ltsapis.goog\\", IOTC_MQTT_PORT}"' in result
+        assert '"MBED_CONF_IOTC_MQTT_HOST={\\"mqtt.2030.ltsapis.goog\\", IOTC_MQTT_PORT}"' in result


### PR DESCRIPTION
### Description

<!--
Please add any detail or context that would be useful to a reviewer.
-->

The CMake list `MBED_CONFIG_DEFINITIONS` in `mbed_config.cmake` generated by `mbed-tools configure` has each item prepended with `-D`. Mbed OS passes this list to `target_compile_definitions()` which supports macros with or without `-D`.

Dropping `-D` from `MBED_CONFIG_DEFINITIONS` makes the style consistent with `MBED_TARGET_DEFINITIONS` and makes it easier for a library or application to check if a given macro is on the list.

### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [x]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
