### PR TITLE
project: CMakeLists.tmpl: Fix project definition

### DIFF
--- a/news/20210720122929.bugfix
+++ b/news/20210720122929.bugfix
@@ -1,0 +1,1 @@
+Fix project definition in CMakeLists.tmpl.

--- a/src/mbed_tools/project/_internal/templates/CMakeLists.tmpl
+++ b/src/mbed_tools/project/_internal/templates/CMakeLists.tmpl
@@ -9,13 +9,13 @@ set(APP_TARGET {{program_name}})
 
 include(${MBED_PATH}/tools/cmake/app.cmake)
 
+project(${APP_TARGET})
+
 add_subdirectory(${MBED_PATH})
 
 add_executable(${APP_TARGET}
     main.cpp
 )
-
-project(${APP_TARGET})
 
 target_link_libraries(${APP_TARGET} mbed-os)
 


### PR DESCRIPTION
### Description

CMake expects the top level application to be specified as the top level
project. To do this we need to define the project before adding
dependencies.



<!--
Please add any detail or context that would be useful to a reviewer.
-->



### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [x]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
