### PR TITLE
config: Add `MBED_GREENTEA_TEST_RESET_TIMEOUT`

### DIFF
--- a/news/20210720.feature
+++ b/news/20210720.feature
@@ -1,0 +1,1 @@
+Get `forced_reset_timeout` from mbed-os/targets/targets.json and add it to generated mbed_config.cmake as `MBED_GREENTEA_TEST_RESET_TIMEOUT` for use by CTest and mbedhtrun.

--- a/src/mbed_tools/build/_internal/templates/mbed_config.tmpl
+++ b/src/mbed_tools/build/_internal/templates/mbed_config.tmpl
@@ -10,6 +10,7 @@ set(MBED_CPU_CORE "{{core}}" CACHE STRING "")
 set(MBED_C_LIB "{{c_lib}}" CACHE STRING "")
 set(MBED_PRINTF_LIB "{{printf_lib}}" CACHE STRING "")
 set(MBED_OUTPUT_EXT "{{OUTPUT_EXT}}" CACHE STRING "")
+set(MBED_GREENTEA_TEST_RESET_TIMEOUT "{{forced_reset_timeout}}" CACHE STRING "")
 
 list(APPEND MBED_TARGET_SUPPORTED_C_LIBS {% for supported_c_lib in supported_c_libs %}
     {{supported_c_lib}}

--- a/tests/build/test_generate_config.py
+++ b/tests/build/test_generate_config.py
@@ -533,3 +533,24 @@ def test_output_ext_hex(program):
     config_text = (program.files.cmake_build_dir / CMAKE_CONFIG_FILE).read_text()
 
     assert 'MBED_OUTPUT_EXT "hex"' in config_text
+
+
+def test_forced_reset_timeout_unspecified(program):
+    generate_config("K64F", "GCC_ARM", program)
+    config_text = (program.files.cmake_build_dir / CMAKE_CONFIG_FILE).read_text()
+
+    assert 'MBED_GREENTEA_TEST_RESET_TIMEOUT ""' in config_text
+
+
+def test_forced_reset_timeout_set(program):
+    target = "IMAGINARYBOARD"
+    toolchain = "GCC_ARM"
+
+    target_data = TARGET_DATA.copy()
+    target_data["forced_reset_timeout"] = 20
+    program.files.custom_targets_json.write_text(json.dumps({target: target_data}))
+
+    generate_config(target, toolchain, program)
+    config_text = (program.files.cmake_build_dir / CMAKE_CONFIG_FILE).read_text()
+
+    assert 'MBED_GREENTEA_TEST_RESET_TIMEOUT "20"' in config_text


### PR DESCRIPTION
### Description

<!--
Please add any detail or context that would be useful to a reviewer.
-->

Targets that take longer to boot (e.g. TF-M targets which boot MCUboot and TF-M before application) have `forced_reset_timeout` in mbed-os/targets/targets.json to increase timeout after reset before starting a Greentea test. This is previously handled by mbedgt, but as we move to CTest and mbedhtrun, a target's reset timeout needs to be available in CMake and passed to mbedhtrun.


### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [x]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
