### PR TITLE
Fix requires handling for baremetal config

### DIFF
--- a/news/20210729080119.bugfix
+++ b/news/20210729080119.bugfix
@@ -1,0 +1,1 @@
+Fix handling of baremetal "requires" configuration.

--- a/src/mbed_tools/build/_internal/config/assemble_build_config.py
+++ b/src/mbed_tools/build/_internal/config/assemble_build_config.py
@@ -84,13 +84,7 @@ def _get_app_filter_labels(mbed_app_data: dict, config: Config) -> None:
 
 
 def _get_file_filter_overrides(mbed_app_data: dict) -> dict:
-    return {
-        "overrides": [
-            override
-            for override in mbed_app_data.get("overrides", [])
-            if override.modifier or override.name == "requires"
-        ]
-    }
+    return {"overrides": [override for override in mbed_app_data.get("overrides", []) if override.modifier]}
 
 
 @dataclass(frozen=True)

--- a/src/mbed_tools/build/_internal/config/config.py
+++ b/src/mbed_tools/build/_internal/config/config.py
@@ -35,10 +35,6 @@ class Config(UserDict):
     def _handle_overrides(self, overrides: Iterable[Override]) -> None:
         for override in overrides:
             logger.debug("Applying override '%s.%s'='%s'", override.namespace, override.name, repr(override.value))
-            if override.name == "requires":
-                self.data["requires"] = self.data.get("requires", set()) | override.value
-                continue
-
             if override.name in self.data:
                 _apply_override(self.data, override)
                 continue

--- a/src/mbed_tools/build/_internal/config/config.py
+++ b/src/mbed_tools/build/_internal/config/config.py
@@ -29,6 +29,8 @@ class Config(UserDict):
             self._handle_overrides(item)
         elif key == MACROS_SECTION:
             self.data[MACROS_SECTION] = self.data.get(MACROS_SECTION, set()) | item
+        elif key == REQUIRES_SECTION:
+            self.data[REQUIRES_SECTION] = self.data.get(REQUIRES_SECTION, set()) | item
         else:
             super().__setitem__(key, item)
 
@@ -71,6 +73,7 @@ class Config(UserDict):
 CONFIG_SECTION = "config"
 MACROS_SECTION = "macros"
 OVERRIDES_SECTION = "overrides"
+REQUIRES_SECTION = "requires"
 
 
 def _apply_override(data: dict, override: Override) -> None:

--- a/src/mbed_tools/build/_internal/config/source.py
+++ b/src/mbed_tools/build/_internal/config/source.py
@@ -101,7 +101,7 @@ class Override:
 def _extract_config_settings(namespace: str, config_data: dict) -> List[ConfigSetting]:
     settings = []
     for name, item in config_data.items():
-        logger.debug("Extracting config setting '%s'='%s'", name, item)
+        logger.debug("Extracting config setting from '%s': '%s'='%s'", namespace, name, item)
         if isinstance(item, dict):
             macro_name = item.get("macro_name")
             help_text = item.get("help")

--- a/src/mbed_tools/build/config.py
+++ b/src/mbed_tools/build/config.py
@@ -19,7 +19,7 @@ CMAKE_CONFIG_FILE = "mbed_config.cmake"
 
 
 def generate_config(target_name: str, toolchain: str, program: MbedProgram) -> Tuple[Config, pathlib.Path]:
-    """Generate an Mbed config file at the program root by parsing the mbed config system.
+    """Generate an Mbed config file after parsing the Mbed config system.
 
     Args:
         target_name: Name of the target to configure for.
@@ -27,7 +27,7 @@ def generate_config(target_name: str, toolchain: str, program: MbedProgram) -> T
         program: The MbedProgram to configure.
 
     Returns:
-        Config object (UserDict)
+        Config object (UserDict).
         Path to the generated config file.
     """
     targets_data = _load_raw_targets_data(program)

--- a/tests/build/_internal/config/test_config.py
+++ b/tests/build/_internal/config/test_config.py
@@ -111,6 +111,14 @@ class TestConfig:
 
         assert conf["macros"] == {"A", "B"}
 
+    def test_requires_are_appended_to(self):
+        conf = Config({"requires": {"A"}})
+
+        conf.update({"requires": {"B"}})
+        conf.update({"requires": {"C"}})
+
+        assert conf["requires"] == {"A", "B", "C"}
+
     def test_warns_and_skips_override_for_undefined_config_parameter(self, caplog):
         conf = Config()
         override_name = "this-does-not-exist"

--- a/tests/build/test_generate_config.py
+++ b/tests/build/test_generate_config.py
@@ -456,30 +456,6 @@ def test_requires_config_option(program):
     assert "MBED_LFS_READ_SIZE=64" not in config_text
 
 
-def test_target_requires_config_option(program):
-    create_mbed_app_json(program.root, target_overrides={"*": {"target.requires": ["ble"]}})
-    create_mbed_lib_json(
-        program.mbed_os.root / "bare-metal" / "mbed_lib.json",
-        "ble",
-        target_overrides={"*": {"target.requires": ["platform"]}},
-    )
-    create_mbed_lib_json(
-        program.mbed_os.root / "platform" / "mbed_lib.json", "platform", config={"stdio-baud-rate": {"value": 9600}},
-    )
-    create_mbed_lib_json(
-        program.mbed_os.root / "storage" / "mbed_lib.json",
-        "filesystem",
-        config={"read_size": {"macro_name": "MBED_LFS_READ_SIZE", "value": 64}},
-    )
-
-    generate_config("K64F", "GCC_ARM", program)
-
-    config_text = (program.files.cmake_build_dir / CMAKE_CONFIG_FILE).read_text()
-
-    assert "MBED_CONF_PLATFORM_STDIO_BAUD_RATE=9600" in config_text
-    assert "MBED_LFS_READ_SIZE=64" not in config_text
-
-
 def test_config_parsed_when_mbed_os_outside_project_root(program_in_mbed_os_subdir, matching_target_and_filter):
     program = program_in_mbed_os_subdir
     target, target_filter = matching_target_and_filter


### PR DESCRIPTION
### Description

<!--
Please add any detail or context that would be useful to a reviewer.
-->
We were previously replacing the list of "requires" if we happened to
find a set of requires not in the app config. This meant occasionally
some config macros would not be defined for baremetal apps depending on
the order the config files were discovered and parsed.

Now we always append to the list of requires, which is how it's supposed
to work.


### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [x]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
