### PR TITLE
config: Add RAM1 memory region parameters to mbed_config.cmake

### DIFF
--- a/news/20210803174602.bugfix
+++ b/news/20210803174602.bugfix
@@ -1,0 +1,1 @@
+Add RAM1 memory region overrides.

--- a/src/mbed_tools/build/_internal/templates/mbed_config.tmpl
+++ b/src/mbed_tools/build/_internal/templates/mbed_config.tmpl
@@ -67,6 +67,12 @@ set(MBED_TARGET_DEFINITIONS{% for component in components %}
 {% if mbed_ram_size is defined %}
     MBED_RAM_SIZE={{ mbed_ram_size | to_hex }}
 {%- endif %}
+{% if mbed_ram1_start is defined %}
+    MBED_RAM1_START={{ mbed_ram1_start | to_hex }}
+{%- endif %}
+{% if mbed_ram1_size is defined %}
+    MBED_RAM1_SIZE={{ mbed_ram1_size | to_hex }}
+{%- endif %}
     TARGET_LIKE_MBED
     __MBED__=1
 )

--- a/tests/build/test_generate_config.py
+++ b/tests/build/test_generate_config.py
@@ -49,6 +49,8 @@ TARGET_DATA = {
     "trustzone": False,
     "mbed_ram_start": "0",
     "mbed_ram_size": "0",
+    "mbed_ram1_start": "0",
+    "mbed_ram1_size": "0",
     "mbed_rom_start": "0",
     "mbed_rom_size": "0",
 }
@@ -297,6 +299,8 @@ def test_overrides_target_config_param_from_app(matching_target_and_filter, prog
         ("target.mbed_rom_size", "1010", "MBED_ROM_SIZE=0x3f2"),
         ("target.mbed_ram_start", "99", "MBED_RAM_START=0x63"),
         ("target.mbed_ram_size", "1010", "MBED_RAM_SIZE=0x3f2"),
+        ("target.mbed_ram1_start", "99", "MBED_RAM1_START=0x63"),
+        ("target.mbed_ram1_size", "1010", "MBED_RAM1_SIZE=0x3f2"),
     ],
 )
 def test_overrides_target_non_config_params_from_app(


### PR DESCRIPTION


### Description
Fixes: #306 
Add RAM1 memory region defines to mbed_config.tmpl as most of the targets
in targets.json has both RAM and RAM1 configurations

<!--
Please add any detail or context that would be useful to a reviewer.
-->



### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [x]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
