### PR TITLE
configure: Generate .mbedignore in build directory

### DIFF
--- a/news/233.bugfix
+++ b/news/233.bugfix
@@ -1,0 +1,1 @@
+Generate .mbedignore in a project's build directory, to prevent Mbed CLI 1 from picking up CMake build files.

--- a/src/mbed_tools/build/config.py
+++ b/src/mbed_tools/build/config.py
@@ -16,6 +16,7 @@ from mbed_tools.build._internal.write_files import write_file
 from mbed_tools.build.exceptions import MbedBuildError
 
 CMAKE_CONFIG_FILE = "mbed_config.cmake"
+MBEDIGNORE_FILE = ".mbedignore"
 
 
 def generate_config(target_name: str, toolchain: str, program: MbedProgram) -> Tuple[Config, pathlib.Path]:
@@ -40,6 +41,8 @@ def generate_config(target_name: str, toolchain: str, program: MbedProgram) -> T
     )
     cmake_config_file_path = program.files.cmake_build_dir / CMAKE_CONFIG_FILE
     write_file(cmake_config_file_path, cmake_file_contents)
+    mbedignore_path = program.files.cmake_build_dir / MBEDIGNORE_FILE
+    write_file(mbedignore_path, "*")
     return config, cmake_config_file_path
 
 

--- a/tests/build/test_generate_config.py
+++ b/tests/build/test_generate_config.py
@@ -4,11 +4,12 @@
 #
 import json
 
+import os
 import pytest
 
 from mbed_tools.project import MbedProgram
 from mbed_tools.build import generate_config
-from mbed_tools.build.config import CMAKE_CONFIG_FILE
+from mbed_tools.build.config import CMAKE_CONFIG_FILE, MBEDIGNORE_FILE
 from mbed_tools.lib.exceptions import ToolsError
 
 
@@ -94,6 +95,17 @@ def program_in_mbed_os_subdir(tmp_path):
 )
 def matching_target_and_filter(request):
     return request.param
+
+
+def test_mbedignore_generated(program):
+    target = "K64F"
+    toolchain = "GCC_ARM"
+
+    generate_config(target, toolchain, program)
+
+    mbedignore_file = (program.files.cmake_build_dir / MBEDIGNORE_FILE)
+
+    assert os.path.isfile(mbedignore_file)
 
 
 def test_target_and_toolchain_collected(program):


### PR DESCRIPTION
### Description

<!--
Please add any detail or context that would be useful to a reviewer.
-->

Mbed CLI 1 scans and builds all files of supported extensions in a project's directory and subdirectories, unless otherwise ignored. If a user has built a project once with mbed-tools and CMake then tries to build it with Mbed CLI 1, the CMake build directory gets accidentally picked up and results in errors.

To resolve this, let mbed-tools generate a .mbedignore file in the build directory.

Fixes #233.

### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [x]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
