### PR TITLE
Add include guard to `mbed_config.cmake`

### DIFF
--- a/azure-pipelines/analyse-and-test.yml
+++ b/azure-pipelines/analyse-and-test.yml
@@ -25,8 +25,8 @@ stages:
               uploadCoverage: "false"
               tox.env: checknews
 
-            Linting_Py_3_6:
-              python.version: '3.6'
+            Linting_Py_3_7:
+              python.version: '3.7'
               vmImageName: ubuntu-latest
               uploadCoverage: "false"
               tox.env: linting
@@ -43,11 +43,11 @@ stages:
               uploadCoverage: "false"
               tox.env: linting
 
-            Linux_Py_3_6:
-              python.version: '3.6'
+            Linux_Py_3_7:
+              python.version: '3.7'
               vmImageName: ubuntu-latest
               uploadCoverage: "false"
-              tox.env: py36
+              tox.env: py37
 
             Linux_Py_3_8:
               python.version: '3.8'
@@ -61,11 +61,11 @@ stages:
               uploadCoverage: "true"
               tox.env: py39
 
-            Windows_Py_3_6:
-              python.version: '3.6'
+            Windows_Py_3_7:
+              python.version: '3.7'
               vmImageName: windows-latest
               uploadCoverage: "false"
-              tox.env: py36
+              tox.env: py37
 
             Windows_Py_3_8:
               python.version: '3.8'
@@ -79,11 +79,11 @@ stages:
               uploadCoverage: "true"
               tox.env: py39
 
-            macOS_Py_3_6:
-              python.version: '3.6'
+            macOS_Py_3_7:
+              python.version: '3.7'
               vmImageName: macOS-latest
               uploadCoverage: "false"
-              tox.env: py36
+              tox.env: py37
 
             macOS_Py_3_8:
               python.version: '3.8'

--- a/news/202112221149.bugfix
+++ b/news/202112221149.bugfix
@@ -1,0 +1,1 @@
+Add `include_guard` to `mbed_config.cmake`. Users can include it in their application and it won't be reprocessed when it's included again by mbed-os.

--- a/src/mbed_tools/build/_internal/templates/mbed_config.tmpl
+++ b/src/mbed_tools/build/_internal/templates/mbed_config.tmpl
@@ -4,6 +4,8 @@
 # Automatically generated configuration file.
 # DO NOT EDIT. Content may be overwritten.
 
+include_guard(GLOBAL)
+
 set(MBED_TOOLCHAIN "{{toolchain_name}}" CACHE STRING "")
 set(MBED_TARGET "{{target_name}}" CACHE STRING "")
 set(MBED_CPU_CORE "{{core}}" CACHE STRING "")


### PR DESCRIPTION
### Description

Some users may want to include `mbed_config.cmake` in their application
`CMakeLists.txt` and modify some of the preset variables. This is
currently impossible: the variables defined in `mbed_config.cmake` will
be overwritten when the file is included again in the mbed-os root
`CMakeLists.txt`.

We can use CMake's `include_guard` feature to force CMake to skip
processing of the file if it has already been processed previously in the
build.

Azure Pipelines have removed Python 3.6 from the macOS-latest runners.
Python3.6 is nearing end of life so we can remove testing for it.

https://www.python.org/dev/peps/pep-0494/#lifespan

### Test Coverage

- [x]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
