### PR TITLE
config: Increase click package required version to 8.1

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/psf/black
-    rev: 19.10b0
+    rev: 22.6.0
     hooks:
       - id: black
 

--- a/news/2022072013030.misc
+++ b/news/2022072013030.misc
@@ -1,0 +1,1 @@
+Increase version of click and black packages

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(
     include_package_data=True,
     install_requires=[
         "python-dotenv",
-        "Click>=7.1,<8",
+        "Click>=7.1,<9",
         "GitPython",
         "tqdm",
         "tabulate",

--- a/tests/cli/test_project_management.py
+++ b/tests/cli/test_project_management.py
@@ -41,13 +41,13 @@ def mock_get_libs():
 class TestNewCommand:
     def test_calls_new_function_with_correct_args(self, mock_initialise_project):
         CliRunner().invoke(new, ["path", "--create-only"])
-        mock_initialise_project.assert_called_once_with(pathlib.Path.cwd() / "path", True)
+        mock_initialise_project.assert_called_once_with(pathlib.Path("path").resolve(), True)
 
     def test_echos_mbed_os_message_when_required(self, mock_initialise_project):
         expected = (
             "Creating a new Mbed program at path "
             + "'"
-            + str(pathlib.Path.cwd() / "path")
+            + str(pathlib.Path("path").resolve())
             + "'"
             + ".\nDownloading mbed-os and adding it to the project.\n"
         )


### PR DESCRIPTION
### Description

The latest version (8.1.3) of the click package is supported in many
projects. E.g. in CHIP project where mbed-os port is implemented.
https://github.com/project-chip/connectedhomeip
In this case, we need to increase the limit of the click version to 8.1.

We need to also update the black package version to be
compatible with the click.

These changes required fix in TestNewCommand class. We need to use
`Path(<file>).resolve()` which is also use in latest click
implementation.
https://github.com/pallets/click/blob/dc918b48fb9006be683a684b42cc7496ad649b83/src/click/types.py#L853

### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [ ]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [x]  Additional tests are not required for this change (e.g. documentation update).
